### PR TITLE
Mark token positions in AST

### DIFF
--- a/lib/lunar/compiler/syntax/parser.lua
+++ b/lib/lunar/compiler/syntax/parser.lua
@@ -773,9 +773,9 @@ end
 function Parser.__index:error_near_next_token(message)
   local next_token = self:consume()
   if next_token then
-    error(message .. " near '" .. next_token.value .. "'")
+    error('[' .. next_token.line .. ":" .. next_token.column .. '] ' .. message .. " near '" .. next_token.value .. "'")
   else
-    error(message .. " near '<EOF>'")
+    error('[' .. next_token.line .. ":" .. next_token.column .. '] ' .. message .. " near '<EOF>'")
   end
 end
 return Parser

--- a/lunar/ast/decls/class_field_declaration.lunar
+++ b/lunar/ast/decls/class_field_declaration.lunar
@@ -25,11 +25,11 @@ class ClassFieldDeclaration << SyntaxNode
     if self.is_static then
       lhs = class_member_expr
     else
-      lhs = Identifier.new("self")
+      lhs = Identifier.new(nil, nil, "self")
     end
 
-    local member_expr = MemberExpression.new(lhs, self.identifier)
-    return AssignmentStatement.new({ member_expr }, SelfAssignmentOpKind.equal_op, { self.value })
+    local member_expr = MemberExpression.new(nil, nil, lhs, self.identifier)
+    return AssignmentStatement.new(nil, nil, { member_expr }, SelfAssignmentOpKind.equal_op, { self.value })
   end
 end
 

--- a/lunar/ast/decls/class_field_declaration.lunar
+++ b/lunar/ast/decls/class_field_declaration.lunar
@@ -6,7 +6,7 @@ local AssignmentStatement = require "lunar.ast.stats.assignment_statement"
 local SelfAssignmentOpKind = require "lunar.ast.stats.self_assignment_op_kind"
 
 class ClassFieldDeclaration << SyntaxNode
-  constructor(is_static, identifier, type_annotation, value)
+  constructor(start_pos, end_pos, is_static, identifier, type_annotation, value)
     super(SyntaxKind.class_field_declaration)
 
     self.is_static = is_static

--- a/lunar/ast/decls/class_field_declaration.lunar
+++ b/lunar/ast/decls/class_field_declaration.lunar
@@ -7,7 +7,7 @@ local SelfAssignmentOpKind = require "lunar.ast.stats.self_assignment_op_kind"
 
 class ClassFieldDeclaration << SyntaxNode
   constructor(start_pos, end_pos, is_static, identifier, type_annotation, value)
-    super(SyntaxKind.class_field_declaration)
+    super(SyntaxKind.class_field_declaration, start_pos, end_pos)
 
     self.is_static = is_static
     self.identifier = identifier

--- a/lunar/ast/decls/class_function_declaration.lunar
+++ b/lunar/ast/decls/class_function_declaration.lunar
@@ -15,8 +15,8 @@ class ClassFunctionDeclaration << SyntaxNode
   end
 
   function lower(class_member_expr)
-    local new_class_member_expr = MemberExpression.new(class_member_expr, self.identifier, not self.is_static)
-    return FunctionStatement.new(new_class_member_expr, self.params, self.block, nil)
+    local new_class_member_expr = MemberExpression.new(nil, nil, class_member_expr, self.identifier, not self.is_static)
+    return FunctionStatement.new(nil, nil, new_class_member_expr, self.params, self.block, nil)
   end
 end
 

--- a/lunar/ast/decls/class_function_declaration.lunar
+++ b/lunar/ast/decls/class_function_declaration.lunar
@@ -4,7 +4,7 @@ local MemberExpression = require "lunar.ast.exprs.member_expression"
 local FunctionStatement = require "lunar.ast.stats.function_statement"
 
 class ClassFunctionDeclaration << SyntaxNode
-  constructor(is_static, identifier, params, block, return_type_annotation)
+  constructor(start_pos, end_pos, is_static, identifier, params, block, return_type_annotation)
     super(SyntaxKind.class_function_declaration)
 
     self.is_static = is_static

--- a/lunar/ast/decls/class_function_declaration.lunar
+++ b/lunar/ast/decls/class_function_declaration.lunar
@@ -5,7 +5,7 @@ local FunctionStatement = require "lunar.ast.stats.function_statement"
 
 class ClassFunctionDeclaration << SyntaxNode
   constructor(start_pos, end_pos, is_static, identifier, params, block, return_type_annotation)
-    super(SyntaxKind.class_function_declaration)
+    super(SyntaxKind.class_function_declaration, start_pos, end_pos)
 
     self.is_static = is_static
     self.identifier = identifier

--- a/lunar/ast/decls/constructor_declaration.lunar
+++ b/lunar/ast/decls/constructor_declaration.lunar
@@ -11,7 +11,7 @@ local ReturnStatement = require "lunar.ast.stats.return_statement"
 local ParameterDeclaration = require "lunar.ast.decls.parameter_declaration"
 
 class ConstructorDeclaration << SyntaxNode
-  constructor(params, block)
+  constructor(start_pos, end_pos, params, block)
     super(SyntaxKind.constructor_declaration)
 
     self.params = params

--- a/lunar/ast/decls/constructor_declaration.lunar
+++ b/lunar/ast/decls/constructor_declaration.lunar
@@ -31,13 +31,13 @@ class ConstructorDeclaration << SyntaxNode
           local super = stat.expr
 
           -- rewrite super_stat to a variable named super that calls new on the super class
-          local super_member_expr = MemberExpression.new(class_base_identifier, Identifier.new("constructor"))
-          local super_call_expr = FunctionCallExpression.new(super_member_expr, {
-            ArgumentExpression.new(Identifier.new("self")), unpack(super.arguments)
+          local super_member_expr = MemberExpression.new(nil, nil, class_base_identifier, Identifier.new(nil, nil, "constructor"))
+          local super_call_expr = FunctionCallExpression.new(nil, nil, super_member_expr, {
+            ArgumentExpression.new(nil, nil, Identifier.new(nil, nil, "self")), unpack(super.arguments)
           })
 
           table.remove(self.block, index)
-          table.insert(self.block, 1, ExpressionStatement.new(super_call_expr))
+          table.insert(self.block, 1, ExpressionStatement.new(nil, nil, super_call_expr))
 
           break
         end
@@ -46,25 +46,25 @@ class ConstructorDeclaration << SyntaxNode
 
     local new_block = {
       -- return
-      ReturnStatement.new({
+      ReturnStatement.new(nil, nil, {
         -- ClassName.constructor()
-        FunctionCallExpression.new(MemberExpression.new(class_identifier, Identifier.new("constructor")), {
+        FunctionCallExpression.new(nil, nil, MemberExpression.new(nil, nil, class_identifier, Identifier.new(nil, nil, "constructor")), {
           -- setmetatable()
-          FunctionCallExpression.new(Identifier.new("setmetatable"), {
+          FunctionCallExpression.new(nil, nil, Identifier.new(nil, nil, "setmetatable"), {
             -- {}, ClassName
-            TableLiteralExpression.new({}), class_identifier
+            TableLiteralExpression.new(nil, nil, {}), class_identifier
           }),
           unpack(self.params)
         })
       })
     }
 
-    table.insert(self.block, ReturnStatement.new({ Identifier.new("self") }))
+    table.insert(self.block, ReturnStatement.new(nil, nil, { Identifier.new(nil, nil, "self") }))
 
     return {
-      new = FunctionStatement.new(MemberExpression.new(class_identifier, Identifier.new("new")), self.params, new_block, nil),
-      constructor = FunctionStatement.new(MemberExpression.new(class_identifier, Identifier.new("constructor")), {
-        ParameterDeclaration.new(Identifier.new("self")), unpack(self.params)
+      new = FunctionStatement.new(nil, nil, MemberExpression.new(nil, nil, class_identifier, Identifier.new(nil, nil, "new")), self.params, new_block, nil),
+      constructor = FunctionStatement.new(nil, nil, MemberExpression.new(nil, nil, class_identifier, Identifier.new(nil, nil, "constructor")), {
+        ParameterDeclaration.new(nil, nil, Identifier.new(nil, nil, "self")), unpack(self.params)
       }, self.block, nil),
     }
   end

--- a/lunar/ast/decls/constructor_declaration.lunar
+++ b/lunar/ast/decls/constructor_declaration.lunar
@@ -12,7 +12,7 @@ local ParameterDeclaration = require "lunar.ast.decls.parameter_declaration"
 
 class ConstructorDeclaration << SyntaxNode
   constructor(start_pos, end_pos, params, block)
-    super(SyntaxKind.constructor_declaration)
+    super(SyntaxKind.constructor_declaration, start_pos, end_pos)
 
     self.params = params
     self.block = block

--- a/lunar/ast/decls/import_value_declaration.lunar
+++ b/lunar/ast/decls/import_value_declaration.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ImportValueDeclaration << SyntaxNode
   constructor(start_pos, end_pos, identifier, is_type, alias_identifier)
-    super(SyntaxKind.import_value_declaration)
+    super(SyntaxKind.import_value_declaration, start_pos, end_pos)
 
     self.identifier = identifier -- Identifier
     self.is_type = is_type -- boolean or nil

--- a/lunar/ast/decls/import_value_declaration.lunar
+++ b/lunar/ast/decls/import_value_declaration.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ImportValueDeclaration << SyntaxNode
-  constructor(identifier, is_type, alias_identifier)
+  constructor(start_pos, end_pos, identifier, is_type, alias_identifier)
     super(SyntaxKind.import_value_declaration)
 
     self.identifier = identifier -- Identifier

--- a/lunar/ast/decls/index_field_declaration.lunar
+++ b/lunar/ast/decls/index_field_declaration.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class IndexFieldDeclaration << SyntaxNode
   constructor(start_pos, end_pos, key, value)
-    super(SyntaxKind.index_field_declaration)
+    super(SyntaxKind.index_field_declaration, start_pos, end_pos)
 
     self.key = key
     self.value = value

--- a/lunar/ast/decls/index_field_declaration.lunar
+++ b/lunar/ast/decls/index_field_declaration.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class IndexFieldDeclaration << SyntaxNode
-  constructor(key, value)
+  constructor(start_pos, end_pos, key, value)
     super(SyntaxKind.index_field_declaration)
 
     self.key = key

--- a/lunar/ast/decls/member_field_declaration.lunar
+++ b/lunar/ast/decls/member_field_declaration.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class MemberFieldDeclaration << SyntaxNode
-  constructor(member_identifier, value)
+  constructor(start_pos, end_pos, member_identifier, value)
     super(SyntaxKind.member_field_declaration)
 
     self.member_identifier = member_identifier

--- a/lunar/ast/decls/member_field_declaration.lunar
+++ b/lunar/ast/decls/member_field_declaration.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class MemberFieldDeclaration << SyntaxNode
   constructor(start_pos, end_pos, member_identifier, value)
-    super(SyntaxKind.member_field_declaration)
+    super(SyntaxKind.member_field_declaration, start_pos, end_pos)
 
     self.member_identifier = member_identifier
     self.value = value

--- a/lunar/ast/decls/parameter_declaration.lunar
+++ b/lunar/ast/decls/parameter_declaration.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ParameterDeclaration << SyntaxNode
   constructor(start_pos, end_pos, identifier)
-    super(SyntaxKind.parameter_declaration)
+    super(SyntaxKind.parameter_declaration, start_pos, end_pos)
 
     self.identifier = identifier
   end

--- a/lunar/ast/decls/parameter_declaration.lunar
+++ b/lunar/ast/decls/parameter_declaration.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ParameterDeclaration << SyntaxNode
-  constructor(identifier)
+  constructor(start_pos, end_pos, identifier)
     super(SyntaxKind.parameter_declaration)
 
     self.identifier = identifier

--- a/lunar/ast/decls/sequential_field_declaration.lunar
+++ b/lunar/ast/decls/sequential_field_declaration.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class SequentialFieldDeclaration << SyntaxNode
-  constructor(value)
+  constructor(start_pos, end_pos, value)
     super(SyntaxKind.sequential_field_declaration)
 
     self.value = value

--- a/lunar/ast/decls/sequential_field_declaration.lunar
+++ b/lunar/ast/decls/sequential_field_declaration.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class SequentialFieldDeclaration << SyntaxNode
   constructor(start_pos, end_pos, value)
-    super(SyntaxKind.sequential_field_declaration)
+    super(SyntaxKind.sequential_field_declaration, start_pos, end_pos)
 
     self.value = value
   end

--- a/lunar/ast/exprs/argument_expression.lunar
+++ b/lunar/ast/exprs/argument_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ArgumentExpression << SyntaxNode
-  constructor(expr)
+  constructor(start_pos, end_pos, expr)
     super(SyntaxKind.argument_expression)
 
     self.value = expr

--- a/lunar/ast/exprs/argument_expression.lunar
+++ b/lunar/ast/exprs/argument_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ArgumentExpression << SyntaxNode
   constructor(start_pos, end_pos, expr)
-    super(SyntaxKind.argument_expression)
+    super(SyntaxKind.argument_expression, start_pos, end_pos)
 
     self.value = expr
   end

--- a/lunar/ast/exprs/binary_op_expression.lunar
+++ b/lunar/ast/exprs/binary_op_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class BinaryOpExpression << SyntaxNode
-  constructor(left_operand, operator, right_operand)
+  constructor(start_pos, end_pos, left_operand, operator, right_operand)
     super(SyntaxKind.binary_op_expression)
 
     self.left_operand = left_operand

--- a/lunar/ast/exprs/binary_op_expression.lunar
+++ b/lunar/ast/exprs/binary_op_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class BinaryOpExpression << SyntaxNode
   constructor(start_pos, end_pos, left_operand, operator, right_operand)
-    super(SyntaxKind.binary_op_expression)
+    super(SyntaxKind.binary_op_expression, start_pos, end_pos)
 
     self.left_operand = left_operand
     self.operator = operator

--- a/lunar/ast/exprs/boolean_literal_expression.lunar
+++ b/lunar/ast/exprs/boolean_literal_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class BooleanLiteralExpression << SyntaxNode
   constructor(start_pos, end_pos, value)
-    super(SyntaxKind.boolean_literal_expression)
+    super(SyntaxKind.boolean_literal_expression, start_pos, end_pos)
 
     self.value = value
   end

--- a/lunar/ast/exprs/boolean_literal_expression.lunar
+++ b/lunar/ast/exprs/boolean_literal_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class BooleanLiteralExpression << SyntaxNode
-  constructor(value)
+  constructor(start_pos, end_pos, value)
     super(SyntaxKind.boolean_literal_expression)
 
     self.value = value

--- a/lunar/ast/exprs/function_call_expression.lunar
+++ b/lunar/ast/exprs/function_call_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class FunctionCallExpression << SyntaxNode
-  constructor(base, arguments)
+  constructor(start_pos, end_pos, base, arguments)
     super(SyntaxKind.function_call_expression)
 
     self.base = base

--- a/lunar/ast/exprs/function_call_expression.lunar
+++ b/lunar/ast/exprs/function_call_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class FunctionCallExpression << SyntaxNode
   constructor(start_pos, end_pos, base, arguments)
-    super(SyntaxKind.function_call_expression)
+    super(SyntaxKind.function_call_expression, start_pos, end_pos)
 
     self.base = base
     self.arguments = arguments

--- a/lunar/ast/exprs/function_expression.lunar
+++ b/lunar/ast/exprs/function_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class FunctionExpression << SyntaxNode
   constructor(start_pos, end_pos, parameters, block, return_type_annotation)
-    super(SyntaxKind.function_expression)
+    super(SyntaxKind.function_expression, start_pos, end_pos)
 
     self.parameters = parameters
     self.block = block

--- a/lunar/ast/exprs/function_expression.lunar
+++ b/lunar/ast/exprs/function_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class FunctionExpression << SyntaxNode
-  constructor(parameters, block, return_type_annotation)
+  constructor(start_pos, end_pos, parameters, block, return_type_annotation)
     super(SyntaxKind.function_expression)
 
     self.parameters = parameters

--- a/lunar/ast/exprs/identifier.lunar
+++ b/lunar/ast/exprs/identifier.lunar
@@ -5,7 +5,7 @@ class Identifier << SyntaxNode
   symbol -- Symbol | nil - The symbol corresponding to this identifier, initialized in binding
 
   constructor(start_pos, end_pos, name, type_annotation)
-    super(SyntaxKind.identifier)
+    super(SyntaxKind.identifier, start_pos, end_pos)
 
     self.name = name
     self.type_annotation = type_annotation

--- a/lunar/ast/exprs/identifier.lunar
+++ b/lunar/ast/exprs/identifier.lunar
@@ -4,7 +4,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 class Identifier << SyntaxNode
   symbol -- Symbol | nil - The symbol corresponding to this identifier, initialized in binding
 
-  constructor(name, type_annotation)
+  constructor(start_pos, end_pos, name, type_annotation)
     super(SyntaxKind.identifier)
 
     self.name = name

--- a/lunar/ast/exprs/index_expression.lunar
+++ b/lunar/ast/exprs/index_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class IndexExpression << SyntaxNode
-  constructor(base, index)
+  constructor(start_pos, end_pos, base, index)
     super(SyntaxKind.index_expression)
 
     self.base = base

--- a/lunar/ast/exprs/index_expression.lunar
+++ b/lunar/ast/exprs/index_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class IndexExpression << SyntaxNode
   constructor(start_pos, end_pos, base, index)
-    super(SyntaxKind.index_expression)
+    super(SyntaxKind.index_expression, start_pos, end_pos)
 
     self.base = base
     self.index = index

--- a/lunar/ast/exprs/lambda_expression.lunar
+++ b/lunar/ast/exprs/lambda_expression.lunar
@@ -4,7 +4,7 @@ local ReturnStatement = require "lunar.ast.stats.return_statement"
 local FunctionExpression = require "lunar.ast.exprs.function_expression"
 
 class LambdaExpression << SyntaxNode
-  constructor(parameters, body, implicit_return, return_type_annotation)
+  constructor(start_pos, end_pos, parameters, body, implicit_return, return_type_annotation)
     super(SyntaxKind.lambda_expression)
 
     self.parameters = parameters

--- a/lunar/ast/exprs/lambda_expression.lunar
+++ b/lunar/ast/exprs/lambda_expression.lunar
@@ -18,13 +18,13 @@ class LambdaExpression << SyntaxNode
 
     if self.implicit_return then
       -- rewrites the body to a return statement
-      block = { ReturnStatement.new({ self.body }) }
+      block = { ReturnStatement.new(nil, nil, { self.body }) }
     else
       -- compatible type, so we simply reuse it
       block = self.body
     end
 
-    return FunctionExpression.new(self.parameters, block)
+    return FunctionExpression.new(nil, nil, self.parameters, block)
   end
 end
 

--- a/lunar/ast/exprs/lambda_expression.lunar
+++ b/lunar/ast/exprs/lambda_expression.lunar
@@ -5,7 +5,7 @@ local FunctionExpression = require "lunar.ast.exprs.function_expression"
 
 class LambdaExpression << SyntaxNode
   constructor(start_pos, end_pos, parameters, body, implicit_return, return_type_annotation)
-    super(SyntaxKind.lambda_expression)
+    super(SyntaxKind.lambda_expression, start_pos, end_pos)
 
     self.parameters = parameters
     self.body = body -- could be a block or a single expression

--- a/lunar/ast/exprs/member_expression.lunar
+++ b/lunar/ast/exprs/member_expression.lunar
@@ -5,7 +5,7 @@ class MemberExpression << SyntaxNode
   constructor(start_pos, end_pos, base, member_identifier, has_colon)
     if has_colon == nil then has_colon = false end
 
-    super(SyntaxKind.member_expression)
+    super(SyntaxKind.member_expression, start_pos, end_pos)
 
     self.base = base
     self.member_identifier = member_identifier

--- a/lunar/ast/exprs/member_expression.lunar
+++ b/lunar/ast/exprs/member_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class MemberExpression << SyntaxNode
-  constructor(base, member_identifier, has_colon)
+  constructor(start_pos, end_pos, base, member_identifier, has_colon)
     if has_colon == nil then has_colon = false end
 
     super(SyntaxKind.member_expression)

--- a/lunar/ast/exprs/nil_literal_expression.lunar
+++ b/lunar/ast/exprs/nil_literal_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class NilLiteralExpression << SyntaxNode
-  constructor()
+  constructor(start_pos, end_pos)
     super(SyntaxKind.nil_literal_expression)
   end
 end

--- a/lunar/ast/exprs/nil_literal_expression.lunar
+++ b/lunar/ast/exprs/nil_literal_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class NilLiteralExpression << SyntaxNode
   constructor(start_pos, end_pos)
-    super(SyntaxKind.nil_literal_expression)
+    super(SyntaxKind.nil_literal_expression, start_pos, end_pos)
   end
 end
 

--- a/lunar/ast/exprs/number_literal_expression.lunar
+++ b/lunar/ast/exprs/number_literal_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class NumberLiteralExpression << SyntaxNode
-  constructor(value)
+  constructor(start_pos, end_pos, value)
     super(SyntaxKind.number_literal_expression)
 
     self.value = value

--- a/lunar/ast/exprs/number_literal_expression.lunar
+++ b/lunar/ast/exprs/number_literal_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class NumberLiteralExpression << SyntaxNode
   constructor(start_pos, end_pos, value)
-    super(SyntaxKind.number_literal_expression)
+    super(SyntaxKind.number_literal_expression, start_pos, end_pos)
 
     self.value = value
   end

--- a/lunar/ast/exprs/prefix_expression.lunar
+++ b/lunar/ast/exprs/prefix_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class PrefixExpression << SyntaxNode
-  constructor(expr)
+  constructor(start_pos, end_pos, expr)
     super(SyntaxKind.prefix_expression)
 
     self.expr = expr

--- a/lunar/ast/exprs/prefix_expression.lunar
+++ b/lunar/ast/exprs/prefix_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class PrefixExpression << SyntaxNode
   constructor(start_pos, end_pos, expr)
-    super(SyntaxKind.prefix_expression)
+    super(SyntaxKind.prefix_expression, start_pos, end_pos)
 
     self.expr = expr
   end

--- a/lunar/ast/exprs/string_literal_expression.lunar
+++ b/lunar/ast/exprs/string_literal_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class StringLiteralExpression << SyntaxNode
-  constructor(value)
+  constructor(start_pos, end_pos, value)
     super(SyntaxKind.string_literal_expression)
 
     self.value = value

--- a/lunar/ast/exprs/string_literal_expression.lunar
+++ b/lunar/ast/exprs/string_literal_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class StringLiteralExpression << SyntaxNode
   constructor(start_pos, end_pos, value)
-    super(SyntaxKind.string_literal_expression)
+    super(SyntaxKind.string_literal_expression, start_pos, end_pos)
 
     self.value = value
   end

--- a/lunar/ast/exprs/table_literal_expression.lunar
+++ b/lunar/ast/exprs/table_literal_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class TableLiteralExpression << SyntaxNode
-  constructor(fields)
+  constructor(start_pos, end_pos, fields)
     super(SyntaxKind.table_literal_expression)
 
     self.fields = fields

--- a/lunar/ast/exprs/table_literal_expression.lunar
+++ b/lunar/ast/exprs/table_literal_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class TableLiteralExpression << SyntaxNode
   constructor(start_pos, end_pos, fields)
-    super(SyntaxKind.table_literal_expression)
+    super(SyntaxKind.table_literal_expression, start_pos, end_pos)
 
     self.fields = fields
   end

--- a/lunar/ast/exprs/type_assertion_expression.lunar
+++ b/lunar/ast/exprs/type_assertion_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class TypeAssertionExpression << SyntaxNode
   constructor(start_pos, end_pos, base, type)
-    super(SyntaxKind.type_assertion_expression)
+    super(SyntaxKind.type_assertion_expression, start_pos, end_pos)
 
     self.base = base
     self.type = type

--- a/lunar/ast/exprs/type_assertion_expression.lunar
+++ b/lunar/ast/exprs/type_assertion_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class TypeAssertionExpression << SyntaxNode
-  constructor(base, type)
+  constructor(start_pos, end_pos, base, type)
     super(SyntaxKind.type_assertion_expression)
 
     self.base = base

--- a/lunar/ast/exprs/unary_op_expression.lunar
+++ b/lunar/ast/exprs/unary_op_expression.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class UnaryOpExpression << SyntaxNode
   constructor(start_pos, end_pos, operator, right_operand)
-    super(SyntaxKind.unary_op_expression)
+    super(SyntaxKind.unary_op_expression, start_pos, end_pos)
 
     self.operator = operator
     self.right_operand = right_operand

--- a/lunar/ast/exprs/unary_op_expression.lunar
+++ b/lunar/ast/exprs/unary_op_expression.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class UnaryOpExpression << SyntaxNode
-  constructor(operator, right_operand)
+  constructor(start_pos, end_pos, operator, right_operand)
     super(SyntaxKind.unary_op_expression)
 
     self.operator = operator

--- a/lunar/ast/exprs/variable_argument_expression.lunar
+++ b/lunar/ast/exprs/variable_argument_expression.lunar
@@ -4,7 +4,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 class VariableArgumentExpression << SyntaxNode
   symbol -- Symbol | nil - The symbol corresponding to this identifier, initialized in binding
 
-  constructor()
+  constructor(start_pos, end_pos)
     super(SyntaxKind.variable_argument_expression)
   end
 end

--- a/lunar/ast/exprs/variable_argument_expression.lunar
+++ b/lunar/ast/exprs/variable_argument_expression.lunar
@@ -5,7 +5,7 @@ class VariableArgumentExpression << SyntaxNode
   symbol -- Symbol | nil - The symbol corresponding to this identifier, initialized in binding
 
   constructor(start_pos, end_pos)
-    super(SyntaxKind.variable_argument_expression)
+    super(SyntaxKind.variable_argument_expression, start_pos, end_pos)
   end
 end
 

--- a/lunar/ast/stats/assignment_statement.lunar
+++ b/lunar/ast/stats/assignment_statement.lunar
@@ -46,7 +46,7 @@ class AssignmentStatement << SyntaxNode
       if variable ~= nil then
         table.insert(variables, variable)
         local op = self.binary_op_map[self.operator]
-        table.insert(exprs, BinaryOpExpression.new(variable, op, expr))
+        table.insert(exprs, BinaryOpExpression.new(nil, nil, variable, op, expr))
       else
         -- simply insert while doing nothing with it
         table.insert(exprs, expr)
@@ -62,11 +62,11 @@ class AssignmentStatement << SyntaxNode
         local variable = self.variables[index]
         table.insert(variables, variable)
         local op = self.binary_op_map[self.operator]
-        table.insert(exprs, BinaryOpExpression.new(variable, op, NilLiteralExpression.new()))
+        table.insert(exprs, BinaryOpExpression.new(nil, nil, variable, op, NilLiteralExpression.new(nil, nil)))
       end
     end
 
-    return AssignmentStatement.new(variables, SelfAssignmentOpKind.equal_op, exprs)
+    return AssignmentStatement.new(nil, nil, variables, SelfAssignmentOpKind.equal_op, exprs)
   end
 end
 

--- a/lunar/ast/stats/assignment_statement.lunar
+++ b/lunar/ast/stats/assignment_statement.lunar
@@ -16,7 +16,7 @@ class AssignmentStatement << SyntaxNode
     [SelfAssignmentOpKind.remainder_equal_op] = BinaryOpKind.modulus_op,
   }
 
-  constructor(variables, operator, exprs)
+  constructor(start_pos, end_pos, variables, operator, exprs)
     super(SyntaxKind.assignment_statement)
 
     self.variables = variables

--- a/lunar/ast/stats/assignment_statement.lunar
+++ b/lunar/ast/stats/assignment_statement.lunar
@@ -17,7 +17,7 @@ class AssignmentStatement << SyntaxNode
   }
 
   constructor(start_pos, end_pos, variables, operator, exprs)
-    super(SyntaxKind.assignment_statement)
+    super(SyntaxKind.assignment_statement, start_pos, end_pos)
 
     self.variables = variables
     self.operator = operator

--- a/lunar/ast/stats/break_statement.lunar
+++ b/lunar/ast/stats/break_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class BreakStatement << SyntaxNode
   constructor(start_pos, end_pos)
-    super(SyntaxKind.break_statement)
+    super(SyntaxKind.break_statement, start_pos, end_pos)
   end
 end
 

--- a/lunar/ast/stats/break_statement.lunar
+++ b/lunar/ast/stats/break_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class BreakStatement << SyntaxNode
-  constructor()
+  constructor(start_pos, end_pos)
     super(SyntaxKind.break_statement)
   end
 end

--- a/lunar/ast/stats/class_statement.lunar
+++ b/lunar/ast/stats/class_statement.lunar
@@ -11,7 +11,7 @@ local ConstructorDeclaration = require "lunar.ast.decls.constructor_declaration"
 local MemberFieldDeclaration = require "lunar.ast.decls.member_field_declaration"
 
 class ClassStatement << SyntaxNode
-  constructor(identifier, super_identifier, members)
+  constructor(start_pos, end_pos, identifier, super_identifier, members)
     super(SyntaxKind.class_statement)
 
     self.identifier = identifier

--- a/lunar/ast/stats/class_statement.lunar
+++ b/lunar/ast/stats/class_statement.lunar
@@ -12,7 +12,7 @@ local MemberFieldDeclaration = require "lunar.ast.decls.member_field_declaration
 
 class ClassStatement << SyntaxNode
   constructor(start_pos, end_pos, identifier, super_identifier, members)
-    super(SyntaxKind.class_statement)
+    super(SyntaxKind.class_statement, start_pos, end_pos)
 
     self.identifier = identifier
     self.super_identifier = super_identifier

--- a/lunar/ast/stats/class_statement.lunar
+++ b/lunar/ast/stats/class_statement.lunar
@@ -20,24 +20,24 @@ class ClassStatement << SyntaxNode
   end
 
   function lower()
-    local empty_table = TableLiteralExpression.new({})
-    local class_def = VariableStatement.new({ self.identifier }, {}, {})
-    local setmt_base = Identifier.new("setmetatable")
+    local empty_table = TableLiteralExpression.new(nil, nil, {})
+    local class_def = VariableStatement.new(nil, nil, { self.identifier }, {}, {})
+    local setmt_base = Identifier.new(nil, nil, "setmetatable")
 
     if self.super_identifier ~= nil then
-      table.insert(class_def.exprlist, FunctionCallExpression.new(setmt_base, {
-        empty_table, TableLiteralExpression.new({
-          MemberFieldDeclaration.new(Identifier.new("__index"), self.super_identifier)
+      table.insert(class_def.exprlist, FunctionCallExpression.new(nil, nil, setmt_base, {
+        empty_table, TableLiteralExpression.new(nil, nil, {
+          MemberFieldDeclaration.new(nil, nil, Identifier.new(nil, nil, "__index"), self.super_identifier)
         })
       }))
     else
       table.insert(class_def.exprlist, empty_table)
     end
 
-    local class_index = MemberExpression.new(self.identifier, Identifier.new("__index"))
-    local class_index_def = AssignmentStatement.new({ class_index }, SelfAssignmentOpKind.equal_op, {})
+    local class_index = MemberExpression.new(nil, nil, self.identifier, Identifier.new(nil, nil, "__index"))
+    local class_index_def = AssignmentStatement.new(nil, nil, { class_index }, SelfAssignmentOpKind.equal_op, {})
     if self.super_identifier ~= nil then
-      table.insert(class_index_def.exprs, FunctionCallExpression.new(setmt_base, {
+      table.insert(class_index_def.exprs, FunctionCallExpression.new(nil, nil, setmt_base, {
         empty_table, self.super_identifier
       }))
     else
@@ -55,7 +55,7 @@ class ClassStatement << SyntaxNode
       end
     end
 
-    ctor_decl = ctor_decl or ConstructorDeclaration.new({}, {})
+    ctor_decl = ctor_decl or ConstructorDeclaration.new(nil, nil, {}, {})
     ctor_decl = ctor_decl:lower(self.identifier, self.super_identifier)
 
     local index = 0

--- a/lunar/ast/stats/declare_global_statement.lunar
+++ b/lunar/ast/stats/declare_global_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DeclareGlobalStatement << SyntaxNode
-  constructor(identifier, is_type_declaration)
+  constructor(start_pos, end_pos, identifier, is_type_declaration)
     super(SyntaxKind.declare_global_statement)
 
     self.identifier = identifier

--- a/lunar/ast/stats/declare_global_statement.lunar
+++ b/lunar/ast/stats/declare_global_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DeclareGlobalStatement << SyntaxNode
   constructor(start_pos, end_pos, identifier, is_type_declaration)
-    super(SyntaxKind.declare_global_statement)
+    super(SyntaxKind.declare_global_statement, start_pos, end_pos)
 
     self.identifier = identifier
     self.is_type_declaration = is_type_declaration

--- a/lunar/ast/stats/declare_package_statement.lunar
+++ b/lunar/ast/stats/declare_package_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DeclarePackageStatement << SyntaxNode
-  constructor(path, type_expr)
+  constructor(start_pos, end_pos, path, type_expr)
     super(SyntaxKind.declare_package_statement)
 
     self.path = path

--- a/lunar/ast/stats/declare_package_statement.lunar
+++ b/lunar/ast/stats/declare_package_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DeclarePackageStatement << SyntaxNode
   constructor(start_pos, end_pos, path, type_expr)
-    super(SyntaxKind.declare_package_statement)
+    super(SyntaxKind.declare_package_statement, start_pos, end_pos)
 
     self.path = path
     self.type_expr = type_expr

--- a/lunar/ast/stats/declare_returns_statement.lunar
+++ b/lunar/ast/stats/declare_returns_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DeclareReturnsStatement << SyntaxNode
-  constructor(type_expr)
+  constructor(start_pos, end_pos, type_expr)
     super(SyntaxKind.declare_returns_statement)
 
     self.type_expr = type_expr

--- a/lunar/ast/stats/declare_returns_statement.lunar
+++ b/lunar/ast/stats/declare_returns_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DeclareReturnsStatement << SyntaxNode
   constructor(start_pos, end_pos, type_expr)
-    super(SyntaxKind.declare_returns_statement)
+    super(SyntaxKind.declare_returns_statement, start_pos, end_pos)
 
     self.type_expr = type_expr
   end

--- a/lunar/ast/stats/do_statement.lunar
+++ b/lunar/ast/stats/do_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DoStatement << SyntaxNode
-  constructor(block)
+  constructor(start_pos, end_pos, block)
     super(SyntaxKind.do_statement)
 
     self.block = block

--- a/lunar/ast/stats/do_statement.lunar
+++ b/lunar/ast/stats/do_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class DoStatement << SyntaxNode
   constructor(start_pos, end_pos, block)
-    super(SyntaxKind.do_statement)
+    super(SyntaxKind.do_statement, start_pos, end_pos)
 
     self.block = block
   end

--- a/lunar/ast/stats/export_statement.lunar
+++ b/lunar/ast/stats/export_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ExportStatement << SyntaxNode
-  constructor(body)
+  constructor(start_pos, end_pos, body)
     super(SyntaxKind.export_statement)
 
     self.body = body

--- a/lunar/ast/stats/export_statement.lunar
+++ b/lunar/ast/stats/export_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ExportStatement << SyntaxNode
   constructor(start_pos, end_pos, body)
-    super(SyntaxKind.export_statement)
+    super(SyntaxKind.export_statement, start_pos, end_pos)
 
     self.body = body
   end

--- a/lunar/ast/stats/expression_statement.lunar
+++ b/lunar/ast/stats/expression_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ExpressionStatement << SyntaxNode
-  constructor(expr)
+  constructor(start_pos, end_pos, expr)
     super(SyntaxKind.expression_statement)
 
     self.expr = expr

--- a/lunar/ast/stats/expression_statement.lunar
+++ b/lunar/ast/stats/expression_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ExpressionStatement << SyntaxNode
   constructor(start_pos, end_pos, expr)
-    super(SyntaxKind.expression_statement)
+    super(SyntaxKind.expression_statement, start_pos, end_pos)
 
     self.expr = expr
   end

--- a/lunar/ast/stats/function_statement.lunar
+++ b/lunar/ast/stats/function_statement.lunar
@@ -5,7 +5,7 @@ class FunctionStatement << SyntaxNode
   constructor(start_pos, end_pos, base, parameters, block, return_type_annotation, is_local)
     if is_local == nil then is_local = false end
 
-    super(SyntaxKind.function_statement)
+    super(SyntaxKind.function_statement, start_pos, end_pos)
 
     self.base = base -- should only be an identifier if is_local is true
     self.parameters = parameters

--- a/lunar/ast/stats/function_statement.lunar
+++ b/lunar/ast/stats/function_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class FunctionStatement << SyntaxNode
-  constructor(base, parameters, block, return_type_annotation, is_local)
+  constructor(start_pos, end_pos, base, parameters, block, return_type_annotation, is_local)
     if is_local == nil then is_local = false end
 
     super(SyntaxKind.function_statement)

--- a/lunar/ast/stats/generic_for_statement.lunar
+++ b/lunar/ast/stats/generic_for_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class GenericForStatement << SyntaxNode
-  constructor(identifiers, exprlist, block)
+  constructor(start_pos, end_pos, identifiers, exprlist, block)
     super(SyntaxKind.generic_for_statement)
 
     self.identifiers = identifiers

--- a/lunar/ast/stats/generic_for_statement.lunar
+++ b/lunar/ast/stats/generic_for_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class GenericForStatement << SyntaxNode
   constructor(start_pos, end_pos, identifiers, exprlist, block)
-    super(SyntaxKind.generic_for_statement)
+    super(SyntaxKind.generic_for_statement, start_pos, end_pos)
 
     self.identifiers = identifiers
     self.exprlist = exprlist

--- a/lunar/ast/stats/if_statement.lunar
+++ b/lunar/ast/stats/if_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class IfStatement << SyntaxNode
-  constructor(expr, block)
+  constructor(start_pos, end_pos, expr, block)
     super(SyntaxKind.if_statement)
 
     self.expr = expr -- unless else branch

--- a/lunar/ast/stats/if_statement.lunar
+++ b/lunar/ast/stats/if_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class IfStatement << SyntaxNode
   constructor(start_pos, end_pos, expr, block)
-    super(SyntaxKind.if_statement)
+    super(SyntaxKind.if_statement, start_pos, end_pos)
 
     self.expr = expr -- unless else branch
     self.block = block

--- a/lunar/ast/stats/import_statement.lunar
+++ b/lunar/ast/stats/import_statement.lunar
@@ -9,7 +9,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ImportStatement << SyntaxNode
-  constructor(path, values, side_effects)
+  constructor(start_pos, end_pos, path, values, side_effects)
     super(SyntaxKind.import_statement)
 
     self.path = path

--- a/lunar/ast/stats/import_statement.lunar
+++ b/lunar/ast/stats/import_statement.lunar
@@ -58,16 +58,16 @@ class ImportStatement << SyntaxNode
     end
 
     if has_value then
-      local source_id = Identifier.new(source_alias)
+      local source_id = Identifier.new(nil, nil, source_alias)
       -- local MyModule = require('path.to.my_module')
       local stats = {
-        VariableStatement.new(
+        VariableStatement.new(nil, nil, 
           {source_id},
           {
-              FunctionCallExpression.new(
-              Identifier.new("require"),
+              FunctionCallExpression.new(nil, nil, 
+              Identifier.new(nil, nil, "require"),
               {
-                ArgumentExpression.new(StringLiteralExpression.new("'" .. self.path .. "'")),
+                ArgumentExpression.new(nil, nil, StringLiteralExpression.new(nil, nil, "'" .. self.path .. "'")),
               }
             )
           }
@@ -76,10 +76,10 @@ class ImportStatement << SyntaxNode
 
       -- local MyExport = MyModule.MyExport
       for value_id, alias_id in pairs(value_map) do
-        table.insert(stats, VariableStatement.new(
+        table.insert(stats, VariableStatement.new(nil, nil, 
           {alias_id},
           {
-            MemberExpression.new(
+            MemberExpression.new(nil, nil, 
               source_id,
               value_id
             )
@@ -91,11 +91,11 @@ class ImportStatement << SyntaxNode
     elseif self.side_effects then
       -- require('path.to.my_module')
       return {
-        ExpressionStatement.new(
-          FunctionCallExpression.new(
-            Identifier.new("require"),
+        ExpressionStatement.new(nil, nil, 
+          FunctionCallExpression.new(nil, nil, 
+            Identifier.new(nil, nil, "require"),
             {
-              ArgumentExpression.new(StringLiteralExpression.new("'" .. self.path .. "'")),
+              ArgumentExpression.new(nil, nil, StringLiteralExpression.new(nil, nil, "'" .. self.path .. "'")),
             }
           )
         )

--- a/lunar/ast/stats/import_statement.lunar
+++ b/lunar/ast/stats/import_statement.lunar
@@ -10,7 +10,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ImportStatement << SyntaxNode
   constructor(start_pos, end_pos, path, values, side_effects)
-    super(SyntaxKind.import_statement)
+    super(SyntaxKind.import_statement, start_pos, end_pos)
 
     self.path = path
     self.values = values

--- a/lunar/ast/stats/range_for_statement.lunar
+++ b/lunar/ast/stats/range_for_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class RangeForStatement << SyntaxNode
   constructor(start_pos, end_pos, identifier, start_expr, end_expr, incremental_expr, block)
-    super(SyntaxKind.range_for_statement)
+    super(SyntaxKind.range_for_statement, start_pos, end_pos)
 
     self.identifier = identifier
     self.start_expr = start_expr

--- a/lunar/ast/stats/range_for_statement.lunar
+++ b/lunar/ast/stats/range_for_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class RangeForStatement << SyntaxNode
-  constructor(identifier, start_expr, end_expr, incremental_expr, block)
+  constructor(start_pos, end_pos, identifier, start_expr, end_expr, incremental_expr, block)
     super(SyntaxKind.range_for_statement)
 
     self.identifier = identifier

--- a/lunar/ast/stats/repeat_until_statement.lunar
+++ b/lunar/ast/stats/repeat_until_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class RepeatUntilStatement << SyntaxNode
   constructor(start_pos, end_pos, block, expr)
-    super(SyntaxKind.repeat_until_statement, start_pos, end_pos)
+    super(SyntaxKind.repeat_until_statement, start_pos, end_post)
 
     self.block = block
     self.expr = expr

--- a/lunar/ast/stats/repeat_until_statement.lunar
+++ b/lunar/ast/stats/repeat_until_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class RepeatUntilStatement << SyntaxNode
-  constructor(block, expr)
+  constructor(start_pos, end_pos, block, expr)
     super(SyntaxKind.repeat_until_statement)
 
     self.block = block

--- a/lunar/ast/stats/repeat_until_statement.lunar
+++ b/lunar/ast/stats/repeat_until_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class RepeatUntilStatement << SyntaxNode
   constructor(start_pos, end_pos, block, expr)
-    super(SyntaxKind.repeat_until_statement)
+    super(SyntaxKind.repeat_until_statement, start_pos, end_pos)
 
     self.block = block
     self.expr = expr

--- a/lunar/ast/stats/return_statement.lunar
+++ b/lunar/ast/stats/return_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ReturnStatement << SyntaxNode
-  constructor(exprlist)
+  constructor(start_pos, end_pos, exprlist)
     super(SyntaxKind.return_statement)
 
     self.exprlist = exprlist

--- a/lunar/ast/stats/return_statement.lunar
+++ b/lunar/ast/stats/return_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class ReturnStatement << SyntaxNode
   constructor(start_pos, end_pos, exprlist)
-    super(SyntaxKind.return_statement)
+    super(SyntaxKind.return_statement, start_pos, end_pos)
 
     self.exprlist = exprlist
   end

--- a/lunar/ast/stats/variable_statement.lunar
+++ b/lunar/ast/stats/variable_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class VariableStatement << SyntaxNode
-  constructor(identlist, exprlist)
+  constructor(start_pos, end_pos, identlist, exprlist)
     super(SyntaxKind.variable_statement)
 
     self.identlist = identlist

--- a/lunar/ast/stats/variable_statement.lunar
+++ b/lunar/ast/stats/variable_statement.lunar
@@ -3,7 +3,7 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class VariableStatement << SyntaxNode
   constructor(start_pos, end_pos, identlist, exprlist)
-    super(SyntaxKind.variable_statement)
+    super(SyntaxKind.variable_statement, start_pos, end_pos)
 
     self.identlist = identlist
     self.exprlist = exprlist

--- a/lunar/ast/stats/while_statement.lunar
+++ b/lunar/ast/stats/while_statement.lunar
@@ -3,8 +3,8 @@ local SyntaxNode = require "lunar.ast.syntax_node"
 
 class WhileStatement << SyntaxNode
   constructor(start_pos, end_pos, expr, block)
-    local super = SyntaxNode.new(SyntaxKind.while_statement)
-    local self = setmetatable(super, WhileStatement)
+    super(SyntaxKind.while_statement, start_pos, end_pos)
+    
     self.expr = expr
     self.block = block
   end

--- a/lunar/ast/stats/while_statement.lunar
+++ b/lunar/ast/stats/while_statement.lunar
@@ -2,7 +2,7 @@ local SyntaxKind = require "lunar.ast.syntax_kind"
 local SyntaxNode = require "lunar.ast.syntax_node"
 
 class WhileStatement << SyntaxNode
-  constructor(expr, block)
+  constructor(start_pos, end_pos, expr, block)
     local super = SyntaxNode.new(SyntaxKind.while_statement)
     local self = setmetatable(super, WhileStatement)
     self.expr = expr

--- a/lunar/ast/syntax_node.lunar
+++ b/lunar/ast/syntax_node.lunar
@@ -1,8 +1,8 @@
 class SyntaxNode
   constructor(syntax_kind, start_pos, end_pos)
     self.syntax_kind = syntax_kind
-    self.start = start_pos
-    self.end = end_pos
+    self.start_pos = start_pos
+    self.end_pos = end_pos
   end
 
   function lower()

--- a/lunar/ast/syntax_node.lunar
+++ b/lunar/ast/syntax_node.lunar
@@ -1,6 +1,8 @@
 class SyntaxNode
-  constructor(syntax_kind)
+  constructor(syntax_kind, start_pos, end_pos)
     self.syntax_kind = syntax_kind
+    self.start = start_pos
+    self.end = end_pos
   end
 
   function lower()

--- a/lunar/compiler/codegen/transpiler.lunar
+++ b/lunar/compiler/codegen/transpiler.lunar
@@ -1,6 +1,7 @@
 local AST = require "lunar.ast"
 local SyntaxKind = require "lunar.ast.syntax_kind"
 local BaseTranspiler = require "lunar.compiler.codegen.base_transpiler"
+local DiagnosticUtils = require "lunar.utils.diagnostic_utils"
 
 class Transpiler << BaseTranspiler
   footer_exports = nil

--- a/lunar/compiler/syntax/base_parser.lunar
+++ b/lunar/compiler/syntax/base_parser.lunar
@@ -126,9 +126,9 @@ class BaseParser
   function error_near_next_token(message)
     local next_token = self:consume()
     if next_token then
-      error(message .. " near '" .. next_token.value .. "'")
+      error(next_token.line .. ":" .. next_token.column .. ': ' .. message .. " near '" .. next_token.value .. "'")
     else
-      error(message .. " near '<EOF>'")
+      error(next_token.line .. ":" .. next_token.column .. ': ' .. message .. " near '<EOF>'")
     end
   end
 

--- a/lunar/compiler/syntax/base_parser.lunar
+++ b/lunar/compiler/syntax/base_parser.lunar
@@ -150,6 +150,16 @@ class BaseParser
       return true
     end
   end
+
+  -- Returns the position of the next nontrivial token
+  function next_nontrivial_pos()
+    return self.position + self:count_trivias()
+  end
+
+  -- Returns the position of the last consumed token
+  function last_consumed_pos()
+    return self.position - 1
+  end
 end
 
 return BaseParser

--- a/lunar/compiler/syntax/base_parser.lunar
+++ b/lunar/compiler/syntax/base_parser.lunar
@@ -156,9 +156,13 @@ class BaseParser
     return self.position + self:count_trivias()
   end
 
-  -- Returns the position of the last consumed token
-  function last_consumed_pos()
-    return self.position - 1
+  -- Returns the position of the last consumed nontrivial token
+  function last_nontrivial_pos()
+    for i = self.position -1, 1, -1 do
+      if not self:is_trivial(self.tokens[i]) then
+        return i
+      end
+    end
   end
 end
 

--- a/lunar/compiler/syntax/parser.lunar
+++ b/lunar/compiler/syntax/parser.lunar
@@ -96,6 +96,8 @@ class Parser << BaseParser
   end
 
   function match_class_member()
+    local start_pos = self:next_nontrivial_pos()
+
     if self:assert_seq("constructor") then
       self:move(1)
       self:expect(TokenType.left_paren, "Expected '(' after 'constructor'")
@@ -104,7 +106,9 @@ class Parser << BaseParser
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'constructor'")
 
-      return AST.ConstructorDeclaration.new(params, block)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.ConstructorDeclaration.new(start_pos, end_pos, params, block)
     end
 
     -- possibly a static member?
@@ -116,6 +120,7 @@ class Parser << BaseParser
 
     if self:match(TokenType.function_keyword) then
       local name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
+      local name_ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
 
       if name == "constructor" then
         error("Unexpected 'constructor' keyword near 'function'")
@@ -134,9 +139,12 @@ class Parser << BaseParser
 
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'function " .. name .. "'")
 
-      return AST.ClassFunctionDeclaration.new(is_static, AST.Identifier.new(name), params, block, return_type_annotation)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.ClassFunctionDeclaration.new(start_pos, end_pos, is_static, name_ident, params, block, return_type_annotation)
     elseif self:assert(TokenType.identifier) then
-      local name = AST.Identifier.new(self:consume().value)
+      local name_value = self:consume().value
+      local name = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name_value)
 
       local type_annotation = nil
       if self:match(TokenType.colon) then
@@ -148,7 +156,9 @@ class Parser << BaseParser
         value = self:expression()
       end
 
-      return AST.ClassFieldDeclaration.new(is_static, name, type_annotation, value)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.ClassFieldDeclaration.new(start_pos, end_pos, is_static, name, type_annotation, value)
     end
 
     -- nothing was returned and we did something with the 'static' token so we need to move the position back
@@ -172,15 +182,18 @@ class Parser << BaseParser
   end
 
   function class_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'class' identifier ['<<' identifier] {class_member} 'end'
     -- 'class' is a contextual keyword that depends on the next token being an identifier
     if self:assert_seq("class", TokenType.identifier) then
       self:move(1)
       local name = self:expect(TokenType.identifier, "Expected identifier after 'class'").value
+      local name_ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
 
       local super_identifier
       if self:match(TokenType.double_left_angle) then
-        super_identifier = AST.Identifier.new(self:expect(TokenType.identifier, "Expected an identifier after '<<'").value)
+        local super_name = self:expect(TokenType.identifier, "Expected an identifier after '<<'").value
+        super_identifier = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), super_name)
       end
 
       local members = {}
@@ -194,11 +207,14 @@ class Parser << BaseParser
       until member == nil
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'class'")
 
-      return AST.ClassStatement.new(AST.Identifier.new(name), super_identifier, members)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.ClassStatement.new(start_pos, end_pos, name_ident, super_identifier, members)
     end
   end
 
   function import_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'from' string 'import' {['type'] (identifier ['as' identifier] | * 'as' identifier)}
     if self:assert_seq("from", TokenType.string, TokenType.import_keyword) then
       self:move(1)
@@ -219,6 +235,8 @@ class Parser << BaseParser
         local value
         if self:assert(TokenType.identifier, TokenType.asterisk) then
           value = self:consume().value
+          local value_decl_start_pos = self:last_consumed_pos()
+          local value_ident() = AST.Identifier.new(value_decl_start_pos, value_decl_start_pos, value)
 
           if value == '*' and is_type then
             error("Unexpected symbol '*' after 'type'")
@@ -232,31 +250,40 @@ class Parser << BaseParser
         -- alias
         local alias
         if self:match(TokenType.as_keyword) then
-          alias = AST.Identifier.new(self:expect(TokenType.identifier, "expected identifier after 'as'").value)
-        elseif value == '*' then
+          local alias_name = self:expect(TokenType.identifier, "expected identifier after 'as'").value
+          alias = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), alias_name)
+        elseif value == '*' then1
           error("expected 'as' after '*'")
         end
 
-        table.insert(values, AST.ImportValueDeclaration.new(AST.Identifier.new(value), is_type, alias))
+        local value_decl_end_pos = self:last_consumed_pos()
+
+        table.insert(values, AST.ImportValueDeclaration.new(value_decl_start_pos, value_decl_end_pos, is_type, alias))
       until not self:match(TokenType.comma)
 
-      return AST.ImportStatement.new(path, values)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.ImportStatement.new(start_pos, end_pos, path, values)
     end
 
     -- 'import' string
     if self:match(TokenType.import_keyword) then
       local path = self:parse_string_contents(self:expect(TokenType.string, "expected string after 'import'"))
-      return AST.ImportStatement.new(path, {}, true)
+      local end_pos = self:last_consumed_pos()
+      return AST.ImportStatement.new(start_pos, end_pos, path, {}, true)
     end
   end
 
   function export_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'export'
     if self:match(TokenType.export_keyword) then
       -- 'export' 'function' identifier '(' [paramlist] ')'
       if self:match(TokenType.function_keyword) then
-        local first_identifier = self:expect(TokenType.identifier, "Expected identifier after 'function'")
-        local base = AST.Identifier.new(first_identifier.value)
+        local func_start_pos = self:last_consumed_pos()
+
+        local first_name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
+        local base = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), first_name)
 
         self:expect(TokenType.left_paren, "Expected '(' to start 'function'")
         local paramlist = self:parameter_list()
@@ -270,17 +297,22 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
 
-        return AST.ExportStatement.new(AST.FunctionStatement.new(base, paramlist, block, return_type_annotation, true))
+        local func_end_pos = self:last_consumed_pos()
+        local func_stat = AST.FunctionStatement.new(func_start_pos, func_end_pos, base, paramlist, block, return_type_annotation, true)
+
+        return AST.ExportStatement.new(start_pos, end_pos, func_start_pos)
       end
 
       -- 'export' class_statement
       local stat = self:class_statement()
       if stat then
-        return AST.ExportStatement.new(stat)
+        return AST.ExportStatement.new(start_pos, self:last_consumed_pos(), stat)
       end
 
       -- 'export' identifier = expression
       if self:assert(TokenType.identifier) then
+        local variable_start_pos = self:next_nontrivial_pos()
+
         local name = self:consume().value
         local type_annotation
         if self:match(TokenType.colon) then
@@ -289,10 +321,11 @@ class Parser << BaseParser
         self:expect(TokenType.equal, "Declaration or statement expected")
         local expr = self:expression()
 
-        return AST.ExportStatement.new(AST.VariableStatement.new(
-          {AST.Identifier.new(name, type_annotation)},
-          {expr}
-        ))
+        local end_pos = self:last_consumed_pos()
+
+        local ident = AST.Identifier.new(variable_start_pos, variable_start_pos, name, type_annotation)
+        local var_stat = AST.VariableStatement.new(variable_start_pos, end_pos, {ident}, {expr})
+        return AST.ExportStatement.new(start_pos, end_pos, ident)
       end
 
       error("Expected function, class, or variable statement to follow 'export'")
@@ -300,11 +333,14 @@ class Parser << BaseParser
   end
 
   function expression_statement()
+    local start_pos = self:next_nontrivial_pos()
+
     local primaryexpr = self:match_primary_expression()
     if primaryexpr ~= nil then
       -- immediately return this if it is a FunctionCallExpression as an ExpressionStatement
       if primaryexpr.syntax_kind == SyntaxKind.function_call_expression then
-        local test = AST.ExpressionStatement.new(primaryexpr)
+        local end_pos = self:last_consumed_pos()
+        local test = AST.ExpressionStatement.new(start_pos, end_pos, primaryexpr)
         return test
       elseif primaryexpr.syntax_kind == SyntaxKind.member_expression
         or primaryexpr.syntax_kind == SyntaxKind.index_expression
@@ -341,7 +377,9 @@ class Parser << BaseParser
         end
         local exprs = self:expression_list()
 
-        return AST.AssignmentStatement.new(variables, self.self_assignment_op_map[op.value], exprs)
+        local end_pos = self:last_consumed_pos()
+
+        return AST.AssignmentStatement.new(start_pos, end_pos, variables, self.self_assignment_op_map[op.value], exprs)
       else
         -- no other cases are allowed from primary_expression, so we bail out and let the error bubble up
         return nil
@@ -350,68 +388,100 @@ class Parser << BaseParser
   end
 
   function do_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'do' block 'end'
     if self:match(TokenType.do_keyword) then
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
+      
+      local end_pos = self:last_consumed_pos()
 
-      return AST.DoStatement.new(block)
+      return AST.DoStatement.new(start_pos, end_pos, block)
     end
   end
 
   function while_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'while' expr 'do' block 'end'
     if self:match(TokenType.while_keyword) then
       local expr = self:expression()
       self:expect(TokenType.do_keyword, "Expected 'do' to close 'while'")
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
+      
+      local end_pos = self:last_consumed_pos()
 
-      return AST.WhileStatement.new(expr, block)
+      return AST.WhileStatement.new(start_pos, end_pos, expr, block)
     end
   end
 
   function repeat_until_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'repeat' block 'until' expr
     if self:match(TokenType.repeat_keyword) then
       local block = self:block()
       self:expect(TokenType.until_keyword, "Expected 'until' to close 'repeat'")
       local expr = self:expression()
+      
+      local end_pos = self:last_consumed_pos()
 
-      return AST.RepeatUntilStatement.new(block, expr)
+      return AST.RepeatUntilStatement.new(start_pos, end_pos, block, expr)
     end
   end
 
+  -- This function should be re-done using separate nodes for each if clause.
+  -- The "if" node class should have no methods.
   function if_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'if' expr 'then' block {'elseif' expr 'then' block} ['else' block] 'end'
     if self:match(TokenType.if_keyword) then
       local expr = self:expression()
       self:expect(TokenType.then_keyword, "Expected 'then' to close 'if'")
       local block = self:block()
-      local if_statement = AST.IfStatement.new(expr, block)
+      local if_statement = AST.IfStatement.new(start_pos, start_pos, expr, block)
 
       while self:match(TokenType.elseif_keyword) do
+        local elseif_start_pos = self:last_consumed_pos()
+
         local elseif_expr = self:expression()
         self:expect(TokenType.then_keyword, "Expected 'then' to close 'elseif'")
         local elseif_block = self:block()
 
-        if_statement:push_elseif(AST.IfStatement.new(elseif_expr, elseif_block))
+        local elseif_end_pos = self:last_consumed_pos()
+
+        if_statement:push_elseif(AST.IfStatement.new(elseif_start_pos, elseif_end_pos, elseif_expr, elseif_block))
       end
 
       if self:match(TokenType.else_keyword) then
+        local else_start_pos = self:last_consumed_pos()
+
         local else_block = self:block()
-        if_statement:set_else(AST.IfStatement.new(nil, else_block))
+
+        local else_end_pos = self:last_consumed_pos()
+        if_statement:set_else(AST.IfStatement.new(else_start_pos, else_end_pos, nil, else_block))
       end
 
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'if'")
+      local end_pos = self:last_consumed_pos()
+      if_statement.end_pos = end_pos
+
       return if_statement
     end
   end
 
   function for_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'for' identifier
     if self:match(TokenType.for_keyword) and self:assert(TokenType.identifier) then
-      local first_identifier = self:consume()
+      local first_name = self:consume().value
+      local first_ident_pos = self:last_consumed_pos()
+
+      local type_annotation = nil
+      if self:match(TokenType.colon) then
+        type_annotation = self:type_expression()
+      end
+
+      local first_identifier = AST.Identifier.new(first_ident_pos, first_ident_pos, first_name, type_annotation)
 
       -- '=' expr ',' expr [',' expr] 'do' block 'end'
       if self:match(TokenType.equal) then
@@ -428,21 +498,25 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'for'")
 
-        return AST.RangeForStatement.new(AST.Identifier.new(first_identifier.value), start_expr, end_expr, incremental_expr, block)
+        local end_pos = self:last_consumed_pos()
+
+        return AST.RangeForStatement.new(start_pos, end_pos, first_identifier, start_expr, end_expr, incremental_expr, block)
       end
 
       -- {',' identifier} 'in' exprlist 'do' block 'end'
       if self:assert(TokenType.comma, TokenType.in_keyword) then
-        local identifiers = { AST.Identifier.new(first_identifier.value) }
+        local identifiers = { first_identifier }
 
         while self:match(TokenType.comma) do
-          local identifier_token = self:expect(TokenType.identifier, "Expected identifier after ','")
+          local value_name = self:expect(TokenType.identifier, "Expected identifier after ','").value
+          local value_ident_pos = self:last_consumed_pos()
+
           local type_annotation = nil
           if self:match(TokenType.colon) then
             type_annotation = self:type_expression()
           end
 
-          table.insert(identifiers, AST.Identifier.new(identifier_token.value, type_annotation))
+          table.insert(identifiers, AST.Identifier.new(value_ident_pos, value_ident_pos identifier_token.value, type_annotation))
         end
 
         self:expect(TokenType.in_keyword, "Expected 'in' after identifier list")
@@ -451,25 +525,32 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'for'")
 
-        return AST.GenericForStatement.new(identifiers, exprlist, block)
+        local end_pos = self:last_consumed_pos()
+
+        return AST.GenericForStatement.new(start_pos, end_pos, identifiers, exprlist, block)
       end
     end
   end
 
   function function_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'function' identifier {'.' identifier} [':' identifier] '(' [paramlist] ')' block 'end'
     if self:match(TokenType.function_keyword) then
-      local first_identifier = self:expect(TokenType.identifier, "Expected identifier after 'function'")
-      local base = AST.Identifier.new(first_identifier.value)
+      local first_name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
+      local member_start_pos = self:last_consumed_pos()
+      local first_identifier = AST.Identifier.new(member_start_pos, member_start_pos, first_name)
+      local base = first_identifier
 
       while self:match(TokenType.dot) do
-        local identifier = self:expect(TokenType.identifier, "Expected identifier after '.'")
-        base = AST.MemberExpression.new(base, AST.Identifier.new(identifier.value))
+        local name = self:expect(TokenType.identifier, "Expected identifier after '.'").value
+        local identifier = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+        base = AST.MemberExpression.new(member_start_pos, self:last_consumed_pos(), base, identifier)
       end
 
       if self:match(TokenType.colon) then
-        local identifier = self:expect(TokenType.identifier, "Expected identifier after ':'")
-        base = AST.MemberExpression.new(base, AST.Identifier.new(identifier.value), true)
+        local name = self:expect(TokenType.identifier, "Expected identifier after ':'").value
+        local identifier = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+        base = AST.MemberExpression.new(member_start_pos, self:last_consumed_pos(), base, identifier, true)
       end
 
       self:expect(TokenType.left_paren, "Expected '(' to start 'function'")
@@ -484,16 +565,21 @@ class Parser << BaseParser
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
 
-      return AST.FunctionStatement.new(base, paramlist, block, return_type_annotation)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.FunctionStatement.new(start_pos, end_pos base, paramlist, block, return_type_annotation)
     end
   end
 
   function variable_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'local'
     if self:match(TokenType.local_keyword) then
       -- 'function' identifier '(' [paramlist] ')' block 'end'
       if self:match(TokenType.function_keyword) then
         local name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
+        local name_ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+
         self:expect(TokenType.left_paren, "Expected '(' to start 'function'")
         local paramlist = self:parameter_list()
         self:expect(TokenType.right_paren, "Expected ')' to close '('")
@@ -506,7 +592,9 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
 
-        return AST.FunctionStatement.new(AST.Identifier.new(name), paramlist, block, return_type_annotation, true)
+        local end_pos = self:last_consumed_pos()
+
+        return AST.FunctionStatement.new(start_pos, end_pos, name_ident, paramlist, block, return_type_annotation, true)
       end
 
       -- identifier {',' identifier} ['=' exprlist]
@@ -518,23 +606,27 @@ class Parser << BaseParser
         repeat
           i = i + 1
           local name = self:expect(TokenType.identifier, "Expected identifier after ','").value
+          local ident_pos = self:last_consumed_pos()
           local type_annotation = nil
           if self:match(TokenType.colon) then
             type_annotation = self:type_expression()
           end
-          table.insert(identlist, AST.Identifier.new(name, type_annotation))
+          table.insert(identlist, AST.Identifier.new(ident_pos, ident_pos, name, type_annotation))
         until not self:match(TokenType.comma)
 
         if self:match(TokenType.equal) then
           exprlist = self:expression_list()
         end
 
-        return AST.VariableStatement.new(identlist, exprlist)
+        local end_pos = self:last_consumed_pos()
+
+        return AST.VariableStatement.new(start_pos, end_pos, identlist, exprlist)
       end
     end
   end
 
   function declare_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'declare' context
     if self:match(TokenType.declare_keyword) then
       local context = self:expect(TokenType.identifier, "Expected declaration context after 'declare'").value
@@ -544,28 +636,34 @@ class Parser << BaseParser
         local identifier
         if self:assert(TokenType.identifier) then
           local name = self:consume().value
+          local name_pos = self:last_consumed_pos()
           local type_annotation
           if self:match(TokenType.colon) then
             type_annotation = self:type_expression()
           end
-          identifier = AST.Identifier.new(name, type_annotation)
+          identifier = AST.Identifier.new(name_pos, name_pos, name, type_annotation)
         else
           -- Todo: handle interfaces, classes, functions, etc.
           error("Expected identifier after 'declare " .. context .. "'")
         end
 
-        return AST.DeclareGlobalStatement.new(identifier, false)
+        local end_pos = self:last_consumed_pos()
+
+        return AST.DeclareGlobalStatement.new(start_pos, end_pos, identifier, false)
       elseif context == "package" then
         -- 'declare' 'package' string_literal_expression type_expression
         local path = self:parse_string_contents(self:expect(TokenType.string, "Expected string after 'declare package'"))
 
         local type = self:type_expression()
-        return AST.DeclarePackageStatement.new(path, type)
+
+        local end_pos = self:last_consumed_pos()
+        return AST.DeclarePackageStatement.new(start_pos, end_pos, path, type)
       elseif context == "returns" then
         -- 'declare' 'returns' type_expression
 
         local type = self:type_expression()
-        return AST.DeclareReturnsStatement.new(type)
+        local end_pos = self:last_consumed_pos()
+        return AST.DeclareReturnsStatement.new(start_pos, end_pos, type)
       else
         error("Expected 'global' 'package' or 'returns' after 'declare' keyword")
       end
@@ -582,9 +680,11 @@ class Parser << BaseParser
   end
 
   function match_last_statement()
+    local start_pos = self:next_nontrivial_pos()
     -- 'break'
     if self:match(TokenType.break_keyword) then
-      return AST.BreakStatement.new()
+      local end_pos = self:last_consumed_pos()
+      return AST.BreakStatement.new(start_pos, end_pos)
     end
 
     -- 'return' [exprlist]
@@ -593,19 +693,24 @@ class Parser << BaseParser
 
       -- prefer nil if there is no expressions
       if #exprlist == 0 then
-        return AST.ReturnStatement.new(nil)
+        local end_pos = self:last_consumed_pos()
+        return AST.ReturnStatement.new(start_pos, end_pos, nil)
       end
 
-      return AST.ReturnStatement.new(exprlist)
+      local end_pos = self:last_consumed_pos()
+      return AST.ReturnStatement.new(start_pos, end_pos, exprlist)
     end
   end
 
   function match_function_arg()
+    local start_pos = self:next_nontrivial_pos()
+
     -- expr
     local expr = self:match_expression()
 
     if expr then
-      return AST.ArgumentExpression.new(expr)
+      local end_pos = self:last_consumed_pos()
+      return AST.ArgumentExpression.new(start_pos, end_pos, expr)
     end
     
     return expr
@@ -635,9 +740,12 @@ class Parser << BaseParser
   end
 
   function match_prefix_expression()
+    local start_pos = self:next_nontrivial_pos()
     -- '(' expr ')'
     if self:match(TokenType.left_paren) then
-      local expr = AST.PrefixExpression.new(self:expression())
+      local inner_expr = self:expression()
+      local end_pos = self:last_consumed_pos()
+      local expr = AST.PrefixExpression.new(start_pos, end_pos, inner_expr)
       self:expect(TokenType.right_paren, "Expected ')' to close '('")
 
       return expr
@@ -645,9 +753,10 @@ class Parser << BaseParser
 
     -- identifier
     if self:assert(TokenType.identifier) then
-      local identifier = self:consume()
+      local name = self:consume().value
+      local ident_pos = self:last_consumed_pos()
 
-      return AST.Identifier.new(identifier.value)
+      return AST.Identifier.new(ident_pos, ident_pos, name)
     end
   end
 
@@ -660,6 +769,7 @@ class Parser << BaseParser
   end
 
   function match_primary_expression()
+    local start_pos = self:next_nontrivial_pos()
     local expr = self:match_prefix_expression()
     
     if not expr then
@@ -668,22 +778,30 @@ class Parser << BaseParser
 
     while true do
       if self:match(TokenType.dot) then
-        local identifier = self:expect(TokenType.identifier, "Expected identifier after '.'")
-        expr = AST.MemberExpression.new(expr, AST.Identifier.new(identifier.value))
+        local name = self:expect(TokenType.identifier, "Expected identifier after '.'").value
+        local ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+
+        local end_pos = self:last_consumed_pos()
+        expr = AST.MemberExpression.new(start_pos, end_pos, expr, ident)
       elseif self:match(TokenType.left_bracket) then
         local inner_expr = self:expression()
         self:expect(TokenType.right_bracket, "Expected ']' to close '['")
-        expr = AST.IndexExpression.new(expr, inner_expr)
+        local end_pos = self:last_consumed_pos()
+        expr = AST.IndexExpression.new(start_pos, end_pos, expr, inner_expr)
       elseif self:match(TokenType.colon) then
-        local identifier = self:expect(TokenType.identifier, "Expected identifier after ':'")
+        local name = self:expect(TokenType.identifier, "Expected identifier after ':'").value
+        local member_end_pos = self:last_consumed_pos()
+        local ident = AST.Identifier.new(member_end_pos, member_end_pos, name)
         local args = self:function_arg_list()
-        expr = AST.FunctionCallExpression.new(
-          AST.MemberExpression.new(expr, AST.Identifier.new(identifier.value), true),
+        local end_pos = self:last_consumed_pos()
+        expr = AST.FunctionCallExpression.new(start_pos, end_pos,
+          AST.MemberExpression.new(start_pos, member_end_pos, expr, ident, true),
           args
         )
       elseif self:assert(TokenType.left_paren, TokenType.string, TokenType.left_brace) then
         local args = self:function_arg_list()
-        expr = AST.FunctionCallExpression.new(expr, args)
+        local end_pos = self:last_consumed_pos()
+        expr = AST.FunctionCallExpression.new(start_pos, end_pos, expr, args)
       else
         return expr
       end
@@ -691,40 +809,47 @@ class Parser << BaseParser
   end
 
   function match_simple_expression()
+    local start_pos = self:next_nontrivial_pos()
     -- 'nil'
     if self:match(TokenType.nil_keyword) then
-      return AST.NilLiteralExpression.new()
+      local end_pos = self:last_consumed_pos()
+      return AST.NilLiteralExpression.new(start_pos, end_pos)
     end
 
     -- 'true' | 'false'
     if self:assert(TokenType.true_keyword, TokenType.false_keyword) then
       local boolean_token = self:consume()
-      return AST.BooleanLiteralExpression.new(boolean_token.token_type == TokenType.true_keyword)
+      local end_pos = self:last_consumed_pos()
+      return AST.BooleanLiteralExpression.new(start_pos, end_pos, boolean_token.token_type == TokenType.true_keyword)
     end
 
     -- number
     if self:assert(TokenType.number) then
       local number_token = self:consume()
-      return AST.NumberLiteralExpression.new(tonumber(number_token.value))
+      local end_pos = self:last_consumed_pos()
+      return AST.NumberLiteralExpression.new(start_pos, end_pos, tonumber(number_token.value))
     end
 
     -- string
     if self:assert(TokenType.string) then
       local string_token = self:consume()
-      return AST.StringLiteralExpression.new(string_token.value)
+      local end_pos = self:last_consumed_pos()
+      return AST.StringLiteralExpression.new(start_pos, end_pos, string_token.value)
     end
 
     -- '{' [fieldlist] '}'
     if self:match(TokenType.left_brace) then
       local fieldlist = self:field_list()
       self:expect(TokenType.right_brace, "Expected '}' to close '{'")
+      local end_pos = self:last_consumed_pos()
 
-      return AST.TableLiteralExpression.new(fieldlist)
+      return AST.TableLiteralExpression.new(start_pos, end_pos, fieldlist)
     end
 
     -- '...'
     if self:match(TokenType.triple_dot) then
-      return AST.VariableArgumentExpression.new()
+      local end_pos = self:last_consumed_pos()
+      return AST.VariableArgumentExpression.new(start_pos, end_pos)
     end
 
     -- 'function' '(' [paramlist] ')' block 'end'
@@ -740,8 +865,9 @@ class Parser << BaseParser
 
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
+        local end_pos = self:last_consumed_pos()
 
-      return AST.FunctionExpression.new(paramlist, block, return_type_annotation)
+      return AST.FunctionExpression.new(start_pos, end_pos, paramlist, block, return_type_annotation)
     end
 
     -- ['|' paramlist '|'] 'do' block 'end | '|' [paramlist] '|' expr
@@ -759,32 +885,37 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
 
-        return AST.LambdaExpression.new(params, block, false, return_type_annotation)
+        local end_pos = self:last_consumed_pos()
+        return AST.LambdaExpression.new(start_pos, end_pos, params, block, false, return_type_annotation)
       else
         local expr = self:expression()
 
-        return AST.LambdaExpression.new(params, expr, true, return_type_annotation)
+        local end_pos = self:last_consumed_pos()
+        return AST.LambdaExpression.new(start_pos, end_pos, params, expr, true, return_type_annotation)
       end
     elseif self:match(TokenType.do_keyword) then
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
 
-      return AST.LambdaExpression.new({}, block, false, nil)
+      local end_pos = self:last_consumed_pos()
+      return AST.LambdaExpression.new(start_pos, end_pos, {}, block, false, nil)
     end
 
     return self:match_primary_expression()
   end
 
   function type_expression()
+    local start_pos = self:next_nontrivial_pos()
     -- Allow certain keywords to overload as type identifiers
     if self:assert(TokenType.nil_keyword)
       or self:assert(TokenType.function_keyword)
       or self:assert(TokenType.true_keyword)
       or self:assert(TokenType.false_keyword) then
-      return AST.Identifier.new(self:consume().value)
+      local end_pos = self:last_consumed_pos()
+      return AST.Identifier.new(start_pos, end_pos, self:consume().value)
     end
     if self:assert(TokenType.identifier) then
-      return AST.Identifier.new(self:consume().value)
+      return AST.Identifier.new(start_pos, end_pos, self:consume().value)
     else
       error("Expected identifier in type expression")
     end
@@ -839,12 +970,26 @@ class Parser << BaseParser
   end
 
   function match_sub_expression(limit)
+    local start_pos = self:next_nontrivial_pos()
     local expr
+
+    -- Type assertions
+    while self:match(TokenType.as_keyword) do
+      -- Parse a type expression
+      if expr == nil then
+        error("unexpected symbol near 'as'")
+      end
+      local type_expr = self:type_expression()
+      local end_pos = self:last_consumed_pos()
+      expr = AST.TypeAssertionExpression.new(start_pos, end_pos, expr, type_expr)
+    end
 
     local unary_op = self:get_unary_op()
     if unary_op ~= nil then
       self:consume()
-      expr = AST.UnaryOpExpression.new(unary_op, self:sub_expression(unary_priority))
+      local end_pos = self:last_consumed_pos()
+      local inner_expr = self:sub_expression(unary_priority)
+      expr = AST.UnaryOpExpression.new(start_pos, end_pos, unary_op, inner_expr)
     else
       expr = self:match_simple_expression()
     end
@@ -853,24 +998,16 @@ class Parser << BaseParser
     -- if binary_op is not nil and left priority of this binary_op is greater than current limit
     while binary_op ~= nil and priority[binary_op][1] > limit do
       self:consume()
-      -- parse a new sub_expression with the right priority of this binary_op
-      local next_expr = self:sub_expression(priority[binary_op][2])
       if expr == nil then
         self:error_near_next_token("unexpected symbol")
       end
-      expr = AST.BinaryOpExpression.new(expr, binary_op, next_expr)
+      -- parse a new sub_expression with the right priority of this binary_op
+      local next_expr = self:sub_expression(priority[binary_op][2])
+      local end_pos = self:last_consumed_pos()
+      expr = AST.BinaryOpExpression.new(start_pos, end_pos, expr, binary_op, next_expr)
 
       -- is there any binary op after this?
       binary_op = self:get_binary_op()
-    end
-
-    -- Type assertions
-    while self:match(TokenType.as_keyword) do
-      -- Parse a type expression
-      if expr == nil then
-        error("unexpected symbol near 'as'")
-      end
-      expr = AST.TypeAssertionExpression.new(expr, self:type_expression())
     end
 
     return expr
@@ -892,16 +1029,21 @@ class Parser << BaseParser
   end
 
   function match_parameter_declaration()
+    local start_pos = self:next_nontrivial_pos()
     -- identifier | '...'
     if self:assert(TokenType.identifier, TokenType.triple_dot) then
-      local param = self:consume()
+      local param = self:consume().value
+      local param_pos = self:last_consumed_pos()
 
       local type_annotation = nil
       if self:match(TokenType.colon) then
         type_annotation = self:type_expression()
       end
 
-      return AST.ParameterDeclaration.new(AST.Identifier.new(param.value, type_annotation))
+      local end_pos = self:last_consumed_pos()
+      
+      local param_ident = AST.Identifier.new(start_pos, param_pos, param, type_annotation)
+      return AST.ParameterDeclaration.new(start_pos, param_ident)
     end
   end
 
@@ -922,6 +1064,7 @@ class Parser << BaseParser
   end
 
   function match_field_declaration()
+    local start_pos = self:next_nontrivial_pos()
     -- '[' expr ']' '=' expr
     if self:match(TokenType.left_bracket) then
       local key = self:expression()
@@ -929,22 +1072,36 @@ class Parser << BaseParser
       self:expect(TokenType.equal, "Expected '=' near ']'")
       local value = self:expression()
 
-      return AST.IndexFieldDeclaration.new(key, value)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.IndexFieldDeclaration.new(start_pos, end_pos, key, value)
     end
 
     -- identifier '=' expr
     if self:assert_seq(TokenType.identifier, TokenType.equal) then
-      local key = self:expect(TokenType.identifier, "Expected identifier to start this field")
+      local key = self:expect(TokenType.identifier, "Expected identifier to start this field").value
+      local key_pos = self:last_consumed_pos()
+
+      local type_annotation = nil
+      if self:match(TokenType.colon) then
+        type_annotation = self:type_expression()
+      end
+
+      local key_ident = AST.Identifier.new(key_pos, key_pos, key, type_annotation)
+
       self:consume() -- consumes the equal token, because we asserted it earlier
       local value = self:expression()
 
-      return AST.MemberFieldDeclaration.new(AST.Identifier.new(key.value), value)
+      local end_pos = self:last_consumed_pos()
+
+      return AST.MemberFieldDeclaration.new(start_pos, end_pos, value)
     end
 
     -- expr
     local value = self:match_expression()
     if value ~= nil then
-      return AST.SequentialFieldDeclaration.new(value)
+      local end_pos = self:last_consumed_pos()
+      return AST.SequentialFieldDeclaration.new(start_pos, end_pos, value)
     end
   end
 

--- a/lunar/compiler/syntax/parser.lunar
+++ b/lunar/compiler/syntax/parser.lunar
@@ -236,7 +236,7 @@ class Parser << BaseParser
         if self:assert(TokenType.identifier, TokenType.asterisk) then
           value = self:consume().value
           local value_decl_start_pos = self:last_consumed_pos()
-          local value_ident() = AST.Identifier.new(value_decl_start_pos, value_decl_start_pos, value)
+          local value_ident = AST.Identifier.new(value_decl_start_pos, value_decl_start_pos, value)
 
           if value == '*' and is_type then
             error("Unexpected symbol '*' after 'type'")
@@ -252,7 +252,7 @@ class Parser << BaseParser
         if self:match(TokenType.as_keyword) then
           local alias_name = self:expect(TokenType.identifier, "expected identifier after 'as'").value
           alias = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), alias_name)
-        elseif value == '*' then1
+        elseif value == '*' then
           error("expected 'as' after '*'")
         end
 
@@ -516,7 +516,7 @@ class Parser << BaseParser
             type_annotation = self:type_expression()
           end
 
-          table.insert(identifiers, AST.Identifier.new(value_ident_pos, value_ident_pos identifier_token.value, type_annotation))
+          table.insert(identifiers, AST.Identifier.new(value_ident_pos, value_ident_pos, identifier_token.value, type_annotation))
         end
 
         self:expect(TokenType.in_keyword, "Expected 'in' after identifier list")
@@ -567,7 +567,7 @@ class Parser << BaseParser
 
       local end_pos = self:last_consumed_pos()
 
-      return AST.FunctionStatement.new(start_pos, end_pos base, paramlist, block, return_type_annotation)
+      return AST.FunctionStatement.new(start_pos, end_pos, base, paramlist, block, return_type_annotation)
     end
   end
 

--- a/lunar/compiler/syntax/parser.lunar
+++ b/lunar/compiler/syntax/parser.lunar
@@ -106,7 +106,7 @@ class Parser << BaseParser
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'constructor'")
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.ConstructorDeclaration.new(start_pos, end_pos, params, block)
     end
@@ -120,7 +120,7 @@ class Parser << BaseParser
 
     if self:match(TokenType.function_keyword) then
       local name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
-      local name_ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+      local name_ident = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), name)
 
       if name == "constructor" then
         error("Unexpected 'constructor' keyword near 'function'")
@@ -139,12 +139,12 @@ class Parser << BaseParser
 
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'function " .. name .. "'")
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.ClassFunctionDeclaration.new(start_pos, end_pos, is_static, name_ident, params, block, return_type_annotation)
     elseif self:assert(TokenType.identifier) then
       local name_value = self:consume().value
-      local name = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name_value)
+      local name = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), name_value)
 
       local type_annotation = nil
       if self:match(TokenType.colon) then
@@ -156,7 +156,7 @@ class Parser << BaseParser
         value = self:expression()
       end
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.ClassFieldDeclaration.new(start_pos, end_pos, is_static, name, type_annotation, value)
     end
@@ -188,12 +188,12 @@ class Parser << BaseParser
     if self:assert_seq("class", TokenType.identifier) then
       self:move(1)
       local name = self:expect(TokenType.identifier, "Expected identifier after 'class'").value
-      local name_ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+      local name_ident = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), name)
 
       local super_identifier
       if self:match(TokenType.double_left_angle) then
         local super_name = self:expect(TokenType.identifier, "Expected an identifier after '<<'").value
-        super_identifier = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), super_name)
+        super_identifier = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), super_name)
       end
 
       local members = {}
@@ -207,7 +207,7 @@ class Parser << BaseParser
       until member == nil
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'class'")
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.ClassStatement.new(start_pos, end_pos, name_ident, super_identifier, members)
     end
@@ -235,7 +235,7 @@ class Parser << BaseParser
         local value, value_ident, value_decl_start_pos
         if self:assert(TokenType.identifier, TokenType.asterisk) then
           value = self:consume().value
-          value_decl_start_pos = self:last_consumed_pos()
+          value_decl_start_pos = self:last_nontrivial_pos()
           value_ident = AST.Identifier.new(value_decl_start_pos, value_decl_start_pos, value)
 
           if value == '*' and is_type then
@@ -252,18 +252,18 @@ class Parser << BaseParser
           local alias
           if self:match(TokenType.as_keyword) then
             local alias_name = self:expect(TokenType.identifier, "expected identifier after 'as'").value
-            alias = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), alias_name)
+            alias = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), alias_name)
           elseif value == '*' then
             error("expected 'as' after '*'")
           end
 
-          local value_decl_end_pos = self:last_consumed_pos()
+          local value_decl_end_pos = self:last_nontrivial_pos()
 
           table.insert(values, AST.ImportValueDeclaration.new(value_decl_start_pos, value_decl_end_pos, value_ident, is_type, alias))
         end
       until not self:match(TokenType.comma)
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.ImportStatement.new(start_pos, end_pos, path, values)
     end
@@ -271,7 +271,7 @@ class Parser << BaseParser
     -- 'import' string
     if self:match(TokenType.import_keyword) then
       local path = self:parse_string_contents(self:expect(TokenType.string, "expected string after 'import'"))
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.ImportStatement.new(start_pos, end_pos, path, {}, true)
     end
   end
@@ -282,10 +282,10 @@ class Parser << BaseParser
     if self:match(TokenType.export_keyword) then
       -- 'export' 'function' identifier '(' [paramlist] ')'
       if self:match(TokenType.function_keyword) then
-        local func_start_pos = self:last_consumed_pos()
+        local func_start_pos = self:last_nontrivial_pos()
 
         local first_name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
-        local base = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), first_name)
+        local base = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), first_name)
 
         self:expect(TokenType.left_paren, "Expected '(' to start 'function'")
         local paramlist = self:parameter_list()
@@ -299,7 +299,7 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
 
-        local func_end_pos = self:last_consumed_pos()
+        local func_end_pos = self:last_nontrivial_pos()
         local func_stat = AST.FunctionStatement.new(func_start_pos, func_end_pos, base, paramlist, block, return_type_annotation, true)
 
         return AST.ExportStatement.new(start_pos, end_pos, func_stat)
@@ -308,7 +308,7 @@ class Parser << BaseParser
       -- 'export' class_statement
       local stat = self:class_statement()
       if stat then
-        return AST.ExportStatement.new(start_pos, self:last_consumed_pos(), stat)
+        return AST.ExportStatement.new(start_pos, self:last_nontrivial_pos(), stat)
       end
 
       -- 'export' identifier = expression
@@ -323,7 +323,7 @@ class Parser << BaseParser
         self:expect(TokenType.equal, "Declaration or statement expected")
         local expr = self:expression()
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
 
         local ident = AST.Identifier.new(variable_start_pos, variable_start_pos, name, type_annotation)
         local var_stat = AST.VariableStatement.new(variable_start_pos, end_pos, {ident}, {expr})
@@ -341,7 +341,7 @@ class Parser << BaseParser
     if primaryexpr ~= nil then
       -- immediately return this if it is a FunctionCallExpression as an ExpressionStatement
       if primaryexpr.syntax_kind == SyntaxKind.function_call_expression then
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         local test = AST.ExpressionStatement.new(start_pos, end_pos, primaryexpr)
         return test
       elseif primaryexpr.syntax_kind == SyntaxKind.member_expression
@@ -379,7 +379,7 @@ class Parser << BaseParser
         end
         local exprs = self:expression_list()
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
 
         return AST.AssignmentStatement.new(start_pos, end_pos, variables, self.self_assignment_op_map[op.value], exprs)
       else
@@ -396,7 +396,7 @@ class Parser << BaseParser
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
       
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.DoStatement.new(start_pos, end_pos, block)
     end
@@ -411,7 +411,7 @@ class Parser << BaseParser
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
       
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.WhileStatement.new(start_pos, end_pos, expr, block)
     end
@@ -425,7 +425,7 @@ class Parser << BaseParser
       self:expect(TokenType.until_keyword, "Expected 'until' to close 'repeat'")
       local expr = self:expression()
       
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.RepeatUntilStatement.new(start_pos, end_pos, block, expr)
     end
@@ -443,28 +443,28 @@ class Parser << BaseParser
       local if_statement = AST.IfStatement.new(start_pos, start_pos, expr, block)
 
       while self:match(TokenType.elseif_keyword) do
-        local elseif_start_pos = self:last_consumed_pos()
+        local elseif_start_pos = self:last_nontrivial_pos()
 
         local elseif_expr = self:expression()
         self:expect(TokenType.then_keyword, "Expected 'then' to close 'elseif'")
         local elseif_block = self:block()
 
-        local elseif_end_pos = self:last_consumed_pos()
+        local elseif_end_pos = self:last_nontrivial_pos()
 
         if_statement:push_elseif(AST.IfStatement.new(elseif_start_pos, elseif_end_pos, elseif_expr, elseif_block))
       end
 
       if self:match(TokenType.else_keyword) then
-        local else_start_pos = self:last_consumed_pos()
+        local else_start_pos = self:last_nontrivial_pos()
 
         local else_block = self:block()
 
-        local else_end_pos = self:last_consumed_pos()
+        local else_end_pos = self:last_nontrivial_pos()
         if_statement:set_else(AST.IfStatement.new(else_start_pos, else_end_pos, nil, else_block))
       end
 
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'if'")
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       if_statement.end_pos = end_pos
 
       return if_statement
@@ -476,7 +476,7 @@ class Parser << BaseParser
     -- 'for' identifier
     if self:match(TokenType.for_keyword) and self:assert(TokenType.identifier) then
       local first_name = self:consume().value
-      local first_ident_pos = self:last_consumed_pos()
+      local first_ident_pos = self:last_nontrivial_pos()
 
       local type_annotation = nil
       if self:match(TokenType.colon) then
@@ -500,7 +500,7 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'for'")
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
 
         return AST.RangeForStatement.new(start_pos, end_pos, first_identifier, start_expr, end_expr, incremental_expr, block)
       end
@@ -511,7 +511,7 @@ class Parser << BaseParser
 
         while self:match(TokenType.comma) do
           local value_name = self:expect(TokenType.identifier, "Expected identifier after ','").value
-          local value_ident_pos = self:last_consumed_pos()
+          local value_ident_pos = self:last_nontrivial_pos()
 
           local type_annotation = nil
           if self:match(TokenType.colon) then
@@ -527,7 +527,7 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'for'")
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
 
         return AST.GenericForStatement.new(start_pos, end_pos, identifiers, exprlist, block)
       end
@@ -539,20 +539,20 @@ class Parser << BaseParser
     -- 'function' identifier {'.' identifier} [':' identifier] '(' [paramlist] ')' block 'end'
     if self:match(TokenType.function_keyword) then
       local first_name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
-      local member_start_pos = self:last_consumed_pos()
+      local member_start_pos = self:last_nontrivial_pos()
       local first_identifier = AST.Identifier.new(member_start_pos, member_start_pos, first_name)
       local base = first_identifier
 
       while self:match(TokenType.dot) do
         local name = self:expect(TokenType.identifier, "Expected identifier after '.'").value
-        local identifier = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
-        base = AST.MemberExpression.new(member_start_pos, self:last_consumed_pos(), base, identifier)
+        local identifier = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), name)
+        base = AST.MemberExpression.new(member_start_pos, self:last_nontrivial_pos(), base, identifier)
       end
 
       if self:match(TokenType.colon) then
         local name = self:expect(TokenType.identifier, "Expected identifier after ':'").value
-        local identifier = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
-        base = AST.MemberExpression.new(member_start_pos, self:last_consumed_pos(), base, identifier, true)
+        local identifier = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), name)
+        base = AST.MemberExpression.new(member_start_pos, self:last_nontrivial_pos(), base, identifier, true)
       end
 
       self:expect(TokenType.left_paren, "Expected '(' to start 'function'")
@@ -567,7 +567,7 @@ class Parser << BaseParser
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.FunctionStatement.new(start_pos, end_pos, base, paramlist, block, return_type_annotation)
     end
@@ -580,7 +580,7 @@ class Parser << BaseParser
       -- 'function' identifier '(' [paramlist] ')' block 'end'
       if self:match(TokenType.function_keyword) then
         local name = self:expect(TokenType.identifier, "Expected identifier after 'function'").value
-        local name_ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+        local name_ident = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), name)
 
         self:expect(TokenType.left_paren, "Expected '(' to start 'function'")
         local paramlist = self:parameter_list()
@@ -594,7 +594,7 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
 
         return AST.FunctionStatement.new(start_pos, end_pos, name_ident, paramlist, block, return_type_annotation, true)
       end
@@ -608,7 +608,7 @@ class Parser << BaseParser
         repeat
           i = i + 1
           local name = self:expect(TokenType.identifier, "Expected identifier after ','").value
-          local ident_pos = self:last_consumed_pos()
+          local ident_pos = self:last_nontrivial_pos()
           local type_annotation = nil
           if self:match(TokenType.colon) then
             type_annotation = self:type_expression()
@@ -620,7 +620,7 @@ class Parser << BaseParser
           exprlist = self:expression_list()
         end
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
 
         return AST.VariableStatement.new(start_pos, end_pos, identlist, exprlist)
       end
@@ -638,7 +638,7 @@ class Parser << BaseParser
         local identifier
         if self:assert(TokenType.identifier) then
           local name = self:consume().value
-          local name_pos = self:last_consumed_pos()
+          local name_pos = self:last_nontrivial_pos()
           local type_annotation
           if self:match(TokenType.colon) then
             type_annotation = self:type_expression()
@@ -649,7 +649,7 @@ class Parser << BaseParser
           error("Expected identifier after 'declare " .. context .. "'")
         end
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
 
         return AST.DeclareGlobalStatement.new(start_pos, end_pos, identifier, false)
       elseif context == "package" then
@@ -658,13 +658,13 @@ class Parser << BaseParser
 
         local type = self:type_expression()
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         return AST.DeclarePackageStatement.new(start_pos, end_pos, path, type)
       elseif context == "returns" then
         -- 'declare' 'returns' type_expression
 
         local type = self:type_expression()
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         return AST.DeclareReturnsStatement.new(start_pos, end_pos, type)
       else
         error("Expected 'global' 'package' or 'returns' after 'declare' keyword")
@@ -685,7 +685,7 @@ class Parser << BaseParser
     local start_pos = self:next_nontrivial_pos()
     -- 'break'
     if self:match(TokenType.break_keyword) then
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.BreakStatement.new(start_pos, end_pos)
     end
 
@@ -695,11 +695,11 @@ class Parser << BaseParser
 
       -- prefer nil if there is no expressions
       if #exprlist == 0 then
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         return AST.ReturnStatement.new(start_pos, end_pos, nil)
       end
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.ReturnStatement.new(start_pos, end_pos, exprlist)
     end
   end
@@ -711,7 +711,7 @@ class Parser << BaseParser
     local expr = self:match_expression()
 
     if expr then
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.ArgumentExpression.new(start_pos, end_pos, expr)
     end
     
@@ -746,17 +746,16 @@ class Parser << BaseParser
     -- '(' expr ')'
     if self:match(TokenType.left_paren) then
       local inner_expr = self:expression()
-      local end_pos = self:last_consumed_pos()
-      local expr = AST.PrefixExpression.new(start_pos, end_pos, inner_expr)
       self:expect(TokenType.right_paren, "Expected ')' to close '('")
 
-      return expr
+      local end_pos = self:last_nontrivial_pos()
+      return AST.PrefixExpression.new(start_pos, end_pos, inner_expr)
     end
 
     -- identifier
     if self:assert(TokenType.identifier) then
       local name = self:consume().value
-      local ident_pos = self:last_consumed_pos()
+      local ident_pos = self:last_nontrivial_pos()
 
       return AST.Identifier.new(ident_pos, ident_pos, name)
     end
@@ -781,28 +780,28 @@ class Parser << BaseParser
     while true do
       if self:match(TokenType.dot) then
         local name = self:expect(TokenType.identifier, "Expected identifier after '.'").value
-        local ident = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), name)
+        local ident = AST.Identifier.new(self:last_nontrivial_pos(), self:last_nontrivial_pos(), name)
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         expr = AST.MemberExpression.new(start_pos, end_pos, expr, ident)
       elseif self:match(TokenType.left_bracket) then
         local inner_expr = self:expression()
         self:expect(TokenType.right_bracket, "Expected ']' to close '['")
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         expr = AST.IndexExpression.new(start_pos, end_pos, expr, inner_expr)
       elseif self:match(TokenType.colon) then
         local name = self:expect(TokenType.identifier, "Expected identifier after ':'").value
-        local member_end_pos = self:last_consumed_pos()
+        local member_end_pos = self:last_nontrivial_pos()
         local ident = AST.Identifier.new(member_end_pos, member_end_pos, name)
         local args = self:function_arg_list()
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         expr = AST.FunctionCallExpression.new(start_pos, end_pos,
           AST.MemberExpression.new(start_pos, member_end_pos, expr, ident, true),
           args
         )
       elseif self:assert(TokenType.left_paren, TokenType.string, TokenType.left_brace) then
         local args = self:function_arg_list()
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         expr = AST.FunctionCallExpression.new(start_pos, end_pos, expr, args)
       else
         return expr
@@ -814,28 +813,28 @@ class Parser << BaseParser
     local start_pos = self:next_nontrivial_pos()
     -- 'nil'
     if self:match(TokenType.nil_keyword) then
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.NilLiteralExpression.new(start_pos, end_pos)
     end
 
     -- 'true' | 'false'
     if self:assert(TokenType.true_keyword, TokenType.false_keyword) then
       local boolean_token = self:consume()
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.BooleanLiteralExpression.new(start_pos, end_pos, boolean_token.token_type == TokenType.true_keyword)
     end
 
     -- number
     if self:assert(TokenType.number) then
       local number_token = self:consume()
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.NumberLiteralExpression.new(start_pos, end_pos, tonumber(number_token.value))
     end
 
     -- string
     if self:assert(TokenType.string) then
       local string_token = self:consume()
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.StringLiteralExpression.new(start_pos, end_pos, string_token.value)
     end
 
@@ -843,14 +842,14 @@ class Parser << BaseParser
     if self:match(TokenType.left_brace) then
       local fieldlist = self:field_list()
       self:expect(TokenType.right_brace, "Expected '}' to close '{'")
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.TableLiteralExpression.new(start_pos, end_pos, fieldlist)
     end
 
     -- '...'
     if self:match(TokenType.triple_dot) then
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.VariableArgumentExpression.new(start_pos, end_pos)
     end
 
@@ -867,7 +866,7 @@ class Parser << BaseParser
 
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.FunctionExpression.new(start_pos, end_pos, paramlist, block, return_type_annotation)
     end
@@ -887,19 +886,19 @@ class Parser << BaseParser
         local block = self:block()
         self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         return AST.LambdaExpression.new(start_pos, end_pos, params, block, false, return_type_annotation)
       else
         local expr = self:expression()
 
-        local end_pos = self:last_consumed_pos()
+        local end_pos = self:last_nontrivial_pos()
         return AST.LambdaExpression.new(start_pos, end_pos, params, expr, true, return_type_annotation)
       end
     elseif self:match(TokenType.do_keyword) then
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'do'")
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.LambdaExpression.new(start_pos, end_pos, {}, block, false, nil)
     end
 
@@ -913,11 +912,14 @@ class Parser << BaseParser
       or self:assert(TokenType.function_keyword)
       or self:assert(TokenType.true_keyword)
       or self:assert(TokenType.false_keyword) then
-      local end_pos = self:last_consumed_pos()
-      return AST.Identifier.new(start_pos, end_pos, self:consume().value)
+      local name = self:consume().value
+      local end_pos = self:last_nontrivial_pos()
+      return AST.Identifier.new(start_pos, end_pos, name)
     end
     if self:assert(TokenType.identifier) then
-      return AST.Identifier.new(start_pos, end_pos, self:consume().value)
+      local name = self:consume().value
+      local end_pos = self:last_nontrivial_pos()
+      return AST.Identifier.new(start_pos, end_pos, name)
     else
       error("Expected identifier in type expression")
     end
@@ -978,8 +980,8 @@ class Parser << BaseParser
     local unary_op = self:get_unary_op()
     if unary_op ~= nil then
       self:consume()
-      local end_pos = self:last_consumed_pos()
       local inner_expr = self:sub_expression(unary_priority)
+      local end_pos = self:last_nontrivial_pos()
       expr = AST.UnaryOpExpression.new(start_pos, end_pos, unary_op, inner_expr)
     else
       expr = self:match_simple_expression()
@@ -994,7 +996,7 @@ class Parser << BaseParser
       end
       -- parse a new sub_expression with the right priority of this binary_op
       local next_expr = self:sub_expression(priority[binary_op][2])
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       expr = AST.BinaryOpExpression.new(start_pos, end_pos, expr, binary_op, next_expr)
 
       -- is there any binary op after this?
@@ -1008,7 +1010,7 @@ class Parser << BaseParser
         error("unexpected symbol near 'as'")
       end
       local type_expr = self:type_expression()
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       expr = AST.TypeAssertionExpression.new(start_pos, end_pos, expr, type_expr)
     end
 
@@ -1035,17 +1037,17 @@ class Parser << BaseParser
     -- identifier | '...'
     if self:assert(TokenType.identifier, TokenType.triple_dot) then
       local param = self:consume().value
-      local param_pos = self:last_consumed_pos()
+      local param_pos = self:last_nontrivial_pos()
 
       local type_annotation = nil
       if self:match(TokenType.colon) then
         type_annotation = self:type_expression()
       end
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       
       local param_ident = AST.Identifier.new(start_pos, param_pos, param, type_annotation)
-      return AST.ParameterDeclaration.new(start_pos, param_pos, param_ident)
+      return AST.ParameterDeclaration.new(start_pos, end_pos, param_ident)
     end
   end
 
@@ -1074,7 +1076,7 @@ class Parser << BaseParser
       self:expect(TokenType.equal, "Expected '=' near ']'")
       local value = self:expression()
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.IndexFieldDeclaration.new(start_pos, end_pos, key, value)
     end
@@ -1082,7 +1084,7 @@ class Parser << BaseParser
     -- identifier '=' expr
     if self:assert_seq(TokenType.identifier, TokenType.equal) then
       local key = self:expect(TokenType.identifier, "Expected identifier to start this field").value
-      local key_pos = self:last_consumed_pos()
+      local key_pos = self:last_nontrivial_pos()
 
       local type_annotation = nil
       if self:match(TokenType.colon) then
@@ -1094,7 +1096,7 @@ class Parser << BaseParser
       self:consume() -- consumes the equal token, because we asserted it earlier
       local value = self:expression()
 
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
 
       return AST.MemberFieldDeclaration.new(start_pos, end_pos, key_ident, value)
     end
@@ -1102,7 +1104,7 @@ class Parser << BaseParser
     -- expr
     local value = self:match_expression()
     if value ~= nil then
-      local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_nontrivial_pos()
       return AST.SequentialFieldDeclaration.new(start_pos, end_pos, value)
     end
   end

--- a/lunar/compiler/syntax/parser.lunar
+++ b/lunar/compiler/syntax/parser.lunar
@@ -232,11 +232,11 @@ class Parser << BaseParser
         end
 
         -- identifier
-        local value
+        local value, value_ident, value_decl_start_pos
         if self:assert(TokenType.identifier, TokenType.asterisk) then
           value = self:consume().value
-          local value_decl_start_pos = self:last_consumed_pos()
-          local value_ident = AST.Identifier.new(value_decl_start_pos, value_decl_start_pos, value)
+          value_decl_start_pos = self:last_consumed_pos()
+          value_ident = AST.Identifier.new(value_decl_start_pos, value_decl_start_pos, value)
 
           if value == '*' and is_type then
             error("Unexpected symbol '*' after 'type'")
@@ -247,18 +247,20 @@ class Parser << BaseParser
           .. "'")
         end
 
-        -- alias
-        local alias
-        if self:match(TokenType.as_keyword) then
-          local alias_name = self:expect(TokenType.identifier, "expected identifier after 'as'").value
-          alias = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), alias_name)
-        elseif value == '*' then
-          error("expected 'as' after '*'")
+        if value then
+          -- alias
+          local alias
+          if self:match(TokenType.as_keyword) then
+            local alias_name = self:expect(TokenType.identifier, "expected identifier after 'as'").value
+            alias = AST.Identifier.new(self:last_consumed_pos(), self:last_consumed_pos(), alias_name)
+          elseif value == '*' then
+            error("expected 'as' after '*'")
+          end
+
+          local value_decl_end_pos = self:last_consumed_pos()
+
+          table.insert(values, AST.ImportValueDeclaration.new(value_decl_start_pos, value_decl_end_pos, value_ident, is_type, alias))
         end
-
-        local value_decl_end_pos = self:last_consumed_pos()
-
-        table.insert(values, AST.ImportValueDeclaration.new(value_decl_start_pos, value_decl_end_pos, is_type, alias))
       until not self:match(TokenType.comma)
 
       local end_pos = self:last_consumed_pos()
@@ -300,7 +302,7 @@ class Parser << BaseParser
         local func_end_pos = self:last_consumed_pos()
         local func_stat = AST.FunctionStatement.new(func_start_pos, func_end_pos, base, paramlist, block, return_type_annotation, true)
 
-        return AST.ExportStatement.new(start_pos, end_pos, func_start_pos)
+        return AST.ExportStatement.new(start_pos, end_pos, func_stat)
       end
 
       -- 'export' class_statement
@@ -325,7 +327,7 @@ class Parser << BaseParser
 
         local ident = AST.Identifier.new(variable_start_pos, variable_start_pos, name, type_annotation)
         local var_stat = AST.VariableStatement.new(variable_start_pos, end_pos, {ident}, {expr})
-        return AST.ExportStatement.new(start_pos, end_pos, ident)
+        return AST.ExportStatement.new(start_pos, end_pos, var_stat)
       end
 
       error("Expected function, class, or variable statement to follow 'export'")
@@ -516,7 +518,7 @@ class Parser << BaseParser
             type_annotation = self:type_expression()
           end
 
-          table.insert(identifiers, AST.Identifier.new(value_ident_pos, value_ident_pos, identifier_token.value, type_annotation))
+          table.insert(identifiers, AST.Identifier.new(value_ident_pos, value_ident_pos, value_name, type_annotation))
         end
 
         self:expect(TokenType.in_keyword, "Expected 'in' after identifier list")
@@ -865,7 +867,7 @@ class Parser << BaseParser
 
       local block = self:block()
       self:expect(TokenType.end_keyword, "Expected 'end' to close 'function'")
-        local end_pos = self:last_consumed_pos()
+      local end_pos = self:last_consumed_pos()
 
       return AST.FunctionExpression.new(start_pos, end_pos, paramlist, block, return_type_annotation)
     end
@@ -973,17 +975,6 @@ class Parser << BaseParser
     local start_pos = self:next_nontrivial_pos()
     local expr
 
-    -- Type assertions
-    while self:match(TokenType.as_keyword) do
-      -- Parse a type expression
-      if expr == nil then
-        error("unexpected symbol near 'as'")
-      end
-      local type_expr = self:type_expression()
-      local end_pos = self:last_consumed_pos()
-      expr = AST.TypeAssertionExpression.new(start_pos, end_pos, expr, type_expr)
-    end
-
     local unary_op = self:get_unary_op()
     if unary_op ~= nil then
       self:consume()
@@ -1008,6 +999,17 @@ class Parser << BaseParser
 
       -- is there any binary op after this?
       binary_op = self:get_binary_op()
+    end
+
+    -- Type assertions
+    while self:match(TokenType.as_keyword) do
+      -- Parse a type expression
+      if expr == nil then
+        error("unexpected symbol near 'as'")
+      end
+      local type_expr = self:type_expression()
+      local end_pos = self:last_consumed_pos()
+      expr = AST.TypeAssertionExpression.new(start_pos, end_pos, expr, type_expr)
     end
 
     return expr
@@ -1043,7 +1045,7 @@ class Parser << BaseParser
       local end_pos = self:last_consumed_pos()
       
       local param_ident = AST.Identifier.new(start_pos, param_pos, param, type_annotation)
-      return AST.ParameterDeclaration.new(start_pos, param_ident)
+      return AST.ParameterDeclaration.new(start_pos, param_pos, param_ident)
     end
   end
 
@@ -1094,7 +1096,7 @@ class Parser << BaseParser
 
       local end_pos = self:last_consumed_pos()
 
-      return AST.MemberFieldDeclaration.new(start_pos, end_pos, value)
+      return AST.MemberFieldDeclaration.new(start_pos, end_pos, key_ident, value)
     end
 
     -- expr

--- a/spec/compiler/semantic/exprs/binder_literal_exprs_spec.lunar
+++ b/spec/compiler/semantic/exprs/binder_literal_exprs_spec.lunar
@@ -11,20 +11,20 @@ describe("Bindings of literal expressions", do
     local var_stat = result[1]
 
     local table_literal_expression = var_stat.exprlist[1]
-    assert.same(AST.TableLiteralExpression.new({
-      AST.SequentialFieldDeclaration.new(
-        AST.NumberLiteralExpression.new(1)
+    assert.same(AST.TableLiteralExpression.new(7, 29, {
+      AST.SequentialFieldDeclaration.new(8, 8,
+        AST.NumberLiteralExpression.new(8, 8, 1)
       ),
-      AST.SequentialFieldDeclaration.new(
-        AST.StringLiteralExpression.new("'hello'")
+      AST.SequentialFieldDeclaration.new(11, 11,
+        AST.StringLiteralExpression.new(11, 11, "'hello'")
       ),
-      AST.IndexFieldDeclaration.new(
-        AST.TableLiteralExpression.new({}),
-        AST.NilLiteralExpression.new()
+      AST.IndexFieldDeclaration.new(14, 21,
+        AST.TableLiteralExpression.new(15, 16, {}),
+        AST.NilLiteralExpression.new(21, 21)
       ),
-      AST.MemberFieldDeclaration.new(
-        AST.Identifier.new('x'),
-        AST.BooleanLiteralExpression.new(true)
+      AST.MemberFieldDeclaration.new(24, 28,
+        AST.Identifier.new(24, 24, 'x'),
+        AST.BooleanLiteralExpression.new(28, 28, true)
       ),
     }), table_literal_expression)
   end)

--- a/spec/compiler/semantic/exprs/binder_op_exprs_spec.lunar
+++ b/spec/compiler/semantic/exprs/binder_op_exprs_spec.lunar
@@ -13,19 +13,19 @@ describe("Bindings of literal expressions", do
     local var_stat = result[1]
 
     local binop_expr = var_stat.exprlist[1]
-    assert.same(AST.BinaryOpExpression.new(
-      AST.NumberLiteralExpression.new(1),
+    assert.same(AST.BinaryOpExpression.new(7, 21,
+      AST.NumberLiteralExpression.new(7, 7, 1),
       AST.BinaryOpKind.and_op,
-      AST.BinaryOpExpression.new(
-        AST.BinaryOpExpression.new(
-          AST.NumberLiteralExpression.new(2),
+      AST.BinaryOpExpression.new(11, 21,
+        AST.BinaryOpExpression.new(11, 15,
+          AST.NumberLiteralExpression.new(11, 11, 2),
           AST.BinaryOpKind.addition_op,
-          AST.NumberLiteralExpression.new(3)
+          AST.NumberLiteralExpression.new(15, 15, 3)
         ),
         AST.BinaryOpKind.equal_op,
-        AST.UnaryOpExpression.new(
+        AST.UnaryOpExpression.new(19, 21,
           AST.UnaryOpKind.length_op,
-          AST.TableLiteralExpression.new({})
+          AST.TableLiteralExpression.new(20, 21, {})
         )
       )
     ), binop_expr)

--- a/spec/compiler/syntax/exprs/parser_binary_op_expr_spec.lunar
+++ b/spec/compiler/syntax/exprs/parser_binary_op_expr_spec.lunar
@@ -7,165 +7,165 @@ describe("BinaryOpExpression syntax", do
     local tokens = Lexer.new("1 + 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.addition_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is subtraction_op", do
     local tokens = Lexer.new("1 - 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.subtraction_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is multiplication_op", do
     local tokens = Lexer.new("1 * 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.multiplication_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is division_op", do
     local tokens = Lexer.new("1 / 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.division_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is modulus_op", do
     local tokens = Lexer.new("1 % 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.modulus_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is power_op", do
     local tokens = Lexer.new("1 ^ 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.power_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are StringLiteralExpression and operator is concatenation_op", do
     local tokens = Lexer.new("'Hello' .. 'world'"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.StringLiteralExpression.new("'Hello'")
+    local left_operand = AST.StringLiteralExpression.new(1, 1, "'Hello'")
     local operator = AST.BinaryOpKind.concatenation_op
-    local right_operand = AST.StringLiteralExpression.new("'world'")
+    local right_operand = AST.StringLiteralExpression.new(5, 5, "'world'")
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are StringLiteralExpression and operator is not_equal_op", do
     local tokens = Lexer.new("'Hello' ~= 'world'"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.StringLiteralExpression.new("'Hello'")
+    local left_operand = AST.StringLiteralExpression.new(1, 1, "'Hello'")
     local operator = AST.BinaryOpKind.not_equal_op
-    local right_operand = AST.StringLiteralExpression.new("'world'")
+    local right_operand = AST.StringLiteralExpression.new(5, 5, "'world'")
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are StringLiteralExpression and operator is equal_op", do
     local tokens = Lexer.new("'Hello' == 'world'"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.StringLiteralExpression.new("'Hello'")
+    local left_operand = AST.StringLiteralExpression.new(1, 1, "'Hello'")
     local operator = AST.BinaryOpKind.equal_op
-    local right_operand = AST.StringLiteralExpression.new("'world'")
+    local right_operand = AST.StringLiteralExpression.new(5, 5, "'world'")
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is less_than_op", do
     local tokens = Lexer.new("1 < 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.less_than_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is less_or_equal_op", do
     local tokens = Lexer.new("1 <= 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.less_or_equal_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is greater_than_op", do
     local tokens = Lexer.new("1 > 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.greater_than_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are NumberLiteralExpression and operator is greater_or_equal_op", do
     local tokens = Lexer.new("1 >= 2"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.NumberLiteralExpression.new(1)
+    local left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
     local operator = AST.BinaryOpKind.greater_or_equal_op
-    local right_operand = AST.NumberLiteralExpression.new(2)
+    local right_operand = AST.NumberLiteralExpression.new(5, 5, 2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are BooleanLiteralExpression and operator is and_op", do
     local tokens = Lexer.new("true and false"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.BooleanLiteralExpression.new(true)
+    local left_operand = AST.BooleanLiteralExpression.new(1, 1, true)
     local operator = AST.BinaryOpKind.and_op
-    local right_operand = AST.BooleanLiteralExpression.new(false)
+    local right_operand = AST.BooleanLiteralExpression.new(5, 5, false)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are BooleanLiteralExpression and operator is or_op", do
     local tokens = Lexer.new("false or true"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local left_operand = AST.BooleanLiteralExpression.new(false)
+    local left_operand = AST.BooleanLiteralExpression.new(1, 1, false)
     local operator = AST.BinaryOpKind.or_op
-    local right_operand = AST.BooleanLiteralExpression.new(true)
+    local right_operand = AST.BooleanLiteralExpression.new(5, 5, true)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, operator, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 5, left_operand, operator, right_operand), result)
   end)
 
   it("should return a BinaryOpExpression node whose operands are BinaryOpExpression and operator is and_op", do
@@ -173,13 +173,15 @@ describe("BinaryOpExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local eq_op = AST.BinaryOpKind.equal_op
-    local true_expr = AST.BooleanLiteralExpression.new(true)
-    local false_expr = AST.BooleanLiteralExpression.new(false)
+    local true_expr_1 = AST.BooleanLiteralExpression.new(1, 1, true)
+    local true_expr_2 = AST.BooleanLiteralExpression.new(5, 5, true)
+    local false_expr_1 = AST.BooleanLiteralExpression.new(9, 9, false)
+    local false_expr_2 = AST.BooleanLiteralExpression.new(13, 13, false)
 
-    local left_operand = AST.BinaryOpExpression.new(true_expr, eq_op, true_expr)
-    local right_operand = AST.BinaryOpExpression.new(false_expr, eq_op, false_expr)
+    local left_operand = AST.BinaryOpExpression.new(1, 5, true_expr_1, eq_op, true_expr_2)
+    local right_operand = AST.BinaryOpExpression.new(9, 13, false_expr_1, eq_op, false_expr_2)
 
-    assert.same(AST.BinaryOpExpression.new(left_operand, AST.BinaryOpKind.and_op, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 13, left_operand, AST.BinaryOpKind.and_op, right_operand), result)
   end)
 
   it("should guard against unfinished binary expressions", do

--- a/spec/compiler/syntax/exprs/parser_prefix_expr_spec.lunar
+++ b/spec/compiler/syntax/exprs/parser_prefix_expr_spec.lunar
@@ -7,36 +7,36 @@ describe("PrefixExpression syntax", do
     local tokens = Lexer.new("1 + (2 + 3)"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local outer_left_operand = AST.NumberLiteralExpression.new(1)
-    local inner_left_operand = AST.NumberLiteralExpression.new(2)
-    local inner_right_operand = AST.NumberLiteralExpression.new(3)
-    local right_operand = AST.PrefixExpression.new(
-      AST.BinaryOpExpression.new(inner_left_operand, AST.BinaryOpKind.addition_op, inner_right_operand)
+    local outer_left_operand = AST.NumberLiteralExpression.new(1, 1, 1)
+    local inner_left_operand = AST.NumberLiteralExpression.new(6, 6, 2)
+    local inner_right_operand = AST.NumberLiteralExpression.new(10, 10, 3)
+    local right_operand = AST.PrefixExpression.new(5, 11,
+      AST.BinaryOpExpression.new(6, 10, inner_left_operand, AST.BinaryOpKind.addition_op, inner_right_operand)
     )
 
-    assert.same(AST.BinaryOpExpression.new(outer_left_operand, AST.BinaryOpKind.addition_op, right_operand), result)
+    assert.same(AST.BinaryOpExpression.new(1, 11, outer_left_operand, AST.BinaryOpKind.addition_op, right_operand), result)
   end)
 
   it("should return an Identifier named hello", do
     local tokens = Lexer.new("hello"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.Identifier.new("hello"), result)
+    assert.same(AST.Identifier.new(1, 1, "hello"), result)
   end)
 
   it("should return a left Identifier named hello with a right MemberExpression named world", do
     local tokens = Lexer.new("hello.world"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.MemberExpression.new(AST.Identifier.new("hello"), AST.Identifier.new("world")), result)
+    assert.same(AST.MemberExpression.new(1, 3, AST.Identifier.new(1, 1, "hello"), AST.Identifier.new(3, 3, "world")), result)
   end)
 
   it("should return a left Identifier named hello with a right IndexExpression of StringLiteralExpression whose value is 'world'", do
     local tokens = Lexer.new("hello['world']"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local index = AST.StringLiteralExpression.new("'world'")
+    local index = AST.StringLiteralExpression.new(3, 3, "'world'")
 
-    assert.same(AST.IndexExpression.new(AST.Identifier.new("hello"), index), result)
+    assert.same(AST.IndexExpression.new(1, 4, AST.Identifier.new(1, 1, "hello"), index), result)
   end)
 end)

--- a/spec/compiler/syntax/exprs/parser_primary_expr_spec.lunar
+++ b/spec/compiler/syntax/exprs/parser_primary_expr_spec.lunar
@@ -7,74 +7,74 @@ describe("SecondaryExpression syntax", do
     local tokens = Lexer.new("hello()"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local base = AST.Identifier.new("hello")
+    local base = AST.Identifier.new(1, 1, "hello")
     local args = {}
 
-    assert.same(AST.FunctionCallExpression.new(base, args), result)
+    assert.same(AST.FunctionCallExpression.new(1, 3, base, args), result)
   end)
 
   it("should return a FunctionCallExpression with three NumberLiteralExpression arguments", do
     local tokens = Lexer.new("testing(1, 2, 3)"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local base = AST.Identifier.new("testing")
+    local base = AST.Identifier.new(1, 1, "testing")
     local args = {
-      AST.ArgumentExpression.new(AST.NumberLiteralExpression.new(1)),
-      AST.ArgumentExpression.new(AST.NumberLiteralExpression.new(2)),
-      AST.ArgumentExpression.new(AST.NumberLiteralExpression.new(3))
+      AST.ArgumentExpression.new(3, 3, AST.NumberLiteralExpression.new(3, 3, 1)),
+      AST.ArgumentExpression.new(6, 6, AST.NumberLiteralExpression.new(6, 6, 2)),
+      AST.ArgumentExpression.new(9, 9, AST.NumberLiteralExpression.new(9, 9, 3))
     }
 
-    assert.same(AST.FunctionCallExpression.new(base, args), result)
+    assert.same(AST.FunctionCallExpression.new(1, 10, base, args), result)
   end)
 
   it("should return a FunctionCallExpression with a IndexExpression using bracket syntax", do
     local tokens = Lexer.new("thank['you'](kanye)"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local index = AST.StringLiteralExpression.new("'you'")
-    local top_member = AST.IndexExpression.new(AST.Identifier.new("thank"), index)
-    local args = { AST.ArgumentExpression.new(AST.Identifier.new("kanye")) }
+    local index = AST.StringLiteralExpression.new(3, 3, "'you'")
+    local top_member = AST.IndexExpression.new(1, 4, AST.Identifier.new(1, 1, "thank"), index)
+    local args = { AST.ArgumentExpression.new(6, 6, AST.Identifier.new(6, 6, "kanye")) }
 
-    assert.same(AST.FunctionCallExpression.new(top_member, args), result)
+    assert.same(AST.FunctionCallExpression.new(1, 7, top_member, args), result)
   end)
 
   it("should return a FunctionCallExpression with dot syntax", do
     local tokens = Lexer.new("very.cool()"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local top_member = AST.MemberExpression.new(AST.Identifier.new("very"), AST.Identifier.new("cool"))
+    local top_member = AST.MemberExpression.new(1, 3, AST.Identifier.new(1, 1, "very"), AST.Identifier.new(3, 3, "cool"))
     local args = {}
 
-    assert.same(AST.FunctionCallExpression.new(top_member, args), result)
+    assert.same(AST.FunctionCallExpression.new(1, 5, top_member, args), result)
   end)
 
   it("should return a FunctionCallExpression with colon syntax", do
     local tokens = Lexer.new("very:nice()"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local top_member = AST.MemberExpression.new(AST.Identifier.new("very"), AST.Identifier.new("nice"), true)
+    local top_member = AST.MemberExpression.new(1, 3, AST.Identifier.new(1, 1, "very"), AST.Identifier.new(3, 3, "nice"), true)
     local args = {}
 
-    assert.same(AST.FunctionCallExpression.new(top_member, args), result)
+    assert.same(AST.FunctionCallExpression.new(1, 5, top_member, args), result)
   end)
 
   it("should return a FunctionCallExpression with a string argument", do
     local tokens = Lexer.new("cool'stuff'"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local base = AST.Identifier.new("cool")
-    local args = { AST.ArgumentExpression.new(AST.StringLiteralExpression.new("'stuff'")) }
+    local base = AST.Identifier.new(1, 1, "cool")
+    local args = { AST.ArgumentExpression.new(2, 2, AST.StringLiteralExpression.new(2, 2, "'stuff'")) }
 
-    assert.same(AST.FunctionCallExpression.new(base, args), result)
+    assert.same(AST.FunctionCallExpression.new(1, 2, base, args), result)
   end)
 
   it("should return a FunctionCallExpression with a table argument", do
     local tokens = Lexer.new("help{}"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local base = AST.Identifier.new("help")
-    local args = { AST.ArgumentExpression.new(AST.TableLiteralExpression.new({})) }
+    local base = AST.Identifier.new(1, 1, "help")
+    local args = { AST.ArgumentExpression.new(2, 3, AST.TableLiteralExpression.new(2, 3, {})) }
 
-    assert.same(AST.FunctionCallExpression.new(base, args), result)
+    assert.same(AST.FunctionCallExpression.new(1, 3, base, args), result)
   end)
 end)

--- a/spec/compiler/syntax/exprs/parser_simple_expr_spec.lunar
+++ b/spec/compiler/syntax/exprs/parser_simple_expr_spec.lunar
@@ -7,52 +7,52 @@ describe("LiteralExpression syntax", do
     local tokens = Lexer.new("nil"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.NilLiteralExpression.new(), result)
+    assert.same(AST.NilLiteralExpression.new(1, 1), result)
   end)
 
   it("should return one BooleanLiteralExpression node given a value of true", do
     local tokens = Lexer.new("true"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.BooleanLiteralExpression.new(true), result)
+    assert.same(AST.BooleanLiteralExpression.new(1, 1, true), result)
   end)
 
   it("should return one BooleanLiteralExpression node given a value of false", do
     local tokens = Lexer.new("false"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.BooleanLiteralExpression.new(false), result)
+    assert.same(AST.BooleanLiteralExpression.new(1, 1, false), result)
   end)
 
   it("should return one NumberLiteralExpression node given a value of 100", do
     local tokens = Lexer.new("100"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.NumberLiteralExpression.new(100), result)
+    assert.same(AST.NumberLiteralExpression.new(1, 1, 100), result)
   end)
 
   it("should return one StringLiteralExpression node given a string value", do
     local tokens = Lexer.new("'Hello, world!'"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.StringLiteralExpression.new("'Hello, world!'"), result)
+    assert.same(AST.StringLiteralExpression.new(1, 1, "'Hello, world!'"), result)
   end)
 
   it("should return one VariableArgumentExpression node", do
     local tokens = Lexer.new("..."):tokenize()
     local result = Parser.new(tokens):expression()
 
-    assert.same(AST.VariableArgumentExpression.new(), result)
+    assert.same(AST.VariableArgumentExpression.new(1, 1), result)
   end)
 
   it("should return one FunctionExpression node whose parameters has two ParameterDeclaration nodes and a BreakStatement block", do
     local tokens = Lexer.new("function(hello, ...) break end"):tokenize()
     local result = Parser.new(tokens):expression()
 
-    local expected_params = { AST.ParameterDeclaration.new(AST.Identifier.new("hello")), AST.ParameterDeclaration.new(AST.Identifier.new("...")) }
-    local expected_block = { AST.BreakStatement.new() }
+    local expected_params = { AST.ParameterDeclaration.new(3, 3, AST.Identifier.new(3, 3, "hello")), AST.ParameterDeclaration.new(6, 6, AST.Identifier.new(6, 6, "...")) }
+    local expected_block = { AST.BreakStatement.new(9, 9) }
 
-    assert.same(AST.FunctionExpression.new(expected_params, expected_block), result)
+    assert.same(AST.FunctionExpression.new(1, 11, expected_params, expected_block), result)
   end)
 
   it("should return one TableLiteralExpression node with three FieldDeclaration nodes", do
@@ -60,12 +60,12 @@ describe("LiteralExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local expected_fields = {
-      AST.IndexFieldDeclaration.new(AST.StringLiteralExpression.new("'hello'"), AST.BooleanLiteralExpression.new(true)),
-      AST.MemberFieldDeclaration.new(AST.Identifier.new("world"), AST.BooleanLiteralExpression.new(false)),
-      AST.SequentialFieldDeclaration.new(AST.NilLiteralExpression.new()),
+      AST.IndexFieldDeclaration.new(3, 9, AST.StringLiteralExpression.new(4, 4, "'hello'"), AST.BooleanLiteralExpression.new(9, 9, true)),
+      AST.MemberFieldDeclaration.new(12, 16, AST.Identifier.new(12, 12, "world"), AST.BooleanLiteralExpression.new(16, 16, false)),
+      AST.SequentialFieldDeclaration.new(19, 19, AST.NilLiteralExpression.new(19, 19)),
     }
 
-    assert.same(AST.TableLiteralExpression.new(expected_fields), result)
+    assert.same(AST.TableLiteralExpression.new(1, 22, expected_fields), result)
   end)
 
   it("should return one LambdaExpression node with two arguments and does not implicitly return", do
@@ -73,21 +73,22 @@ describe("LiteralExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local expected_params = {
-      AST.ParameterDeclaration.new(AST.Identifier.new("a")),
-      AST.ParameterDeclaration.new(AST.Identifier.new("b"))
+      AST.ParameterDeclaration.new(2, 2, AST.Identifier.new(2, 2, "a")),
+      AST.ParameterDeclaration.new(5, 5, AST.Identifier.new(5, 5, "b"))
     }
 
     local expected_block = {
-      AST.ReturnStatement.new({
+      AST.ReturnStatement.new(10, 16, {
         AST.BinaryOpExpression.new(
-          AST.Identifier.new("a"),
+          12, 16,
+          AST.Identifier.new(12, 12, "a"),
           AST.BinaryOpKind.addition_op,
-          AST.Identifier.new("b")
+          AST.Identifier.new(16, 16, "b")
         )
       })
     }
 
-    assert.same(AST.LambdaExpression.new(expected_params, expected_block, false), result)
+    assert.same(AST.LambdaExpression.new(1, 18, expected_params, expected_block, false), result)
   end)
 
   it("should return one LambdaExpression with a return type annotation of 'number'", do
@@ -97,14 +98,14 @@ describe("LiteralExpression syntax", do
     local expected_params = {}
 
     local expected_block = {
-      AST.ReturnStatement.new({
-        AST.NumberLiteralExpression.new(1)
+      AST.ReturnStatement.new(9, 11, {
+        AST.NumberLiteralExpression.new(11, 11, 1)
       })
     }
 
-    local expected_return_annotaiton = AST.Identifier.new("number")
+    local expected_return_annotaiton = AST.Identifier.new(5, 5, "number")
 
-    assert.same(AST.LambdaExpression.new(expected_params, expected_block, false, expected_return_annotaiton), result)
+    assert.same(AST.LambdaExpression.new(1, 13, expected_params, expected_block, false, expected_return_annotaiton), result)
   end)
 
   it("should return one LambdaExpression with a return type annotation of 'number' and an implicit return", do
@@ -113,11 +114,11 @@ describe("LiteralExpression syntax", do
 
     local expected_params = {}
 
-    local expected_expr = AST.NumberLiteralExpression.new(1)
+    local expected_expr = AST.NumberLiteralExpression.new(7, 7, 1)
 
-    local expected_return_annotaiton = AST.Identifier.new("number")
+    local expected_return_annotaiton = AST.Identifier.new(5, 5, "number")
 
-    assert.same(AST.LambdaExpression.new(expected_params, expected_expr, true, expected_return_annotaiton), result)
+    assert.same(AST.LambdaExpression.new(1, 7, expected_params, expected_expr, true, expected_return_annotaiton), result)
   end)
 
   it("should return one LambdaExpression node without any arguments and does not implicitly return", do
@@ -125,10 +126,10 @@ describe("LiteralExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local expected_block = {
-      AST.ReturnStatement.new({ AST.NumberLiteralExpression.new(1) })
+      AST.ReturnStatement.new(3, 5, { AST.NumberLiteralExpression.new(5, 5, 1) })
     }
 
-    assert.same(AST.LambdaExpression.new({}, expected_block, false), result)
+    assert.same(AST.LambdaExpression.new(1, 7, {}, expected_block, false), result)
   end)
 
   it("should return one LambdaExpression node with two arguments and does implicitly return", do
@@ -136,16 +137,17 @@ describe("LiteralExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local expected_params = {
-      AST.ParameterDeclaration.new(AST.Identifier.new("a")),
-      AST.ParameterDeclaration.new(AST.Identifier.new("b"))
+      AST.ParameterDeclaration.new(2, 2, AST.Identifier.new(2, 2, "a")),
+      AST.ParameterDeclaration.new(5, 5, AST.Identifier.new(5, 5, "b"))
     }
 
     local expected_expr = AST.BinaryOpExpression.new(
-      AST.Identifier.new("a"),
+      8, 12,
+      AST.Identifier.new(8, 8, "a"),
       AST.BinaryOpKind.addition_op,
-      AST.Identifier.new("b")
+      AST.Identifier.new(12, 12, "b")
     )
 
-    assert.same(AST.LambdaExpression.new(expected_params, expected_expr, true), result)
+    assert.same(AST.LambdaExpression.new(1, 12, expected_params, expected_expr, true), result)
   end)
 end)

--- a/spec/compiler/syntax/exprs/parser_unary_op_expr_spec.lunar
+++ b/spec/compiler/syntax/exprs/parser_unary_op_expr_spec.lunar
@@ -8,9 +8,9 @@ describe("UnaryOpExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local operator = AST.UnaryOpKind.not_op
-    local operand = AST.BooleanLiteralExpression.new(false)
+    local operand = AST.BooleanLiteralExpression.new(3, 3, false)
 
-    assert.same(AST.UnaryOpExpression.new(operator, operand), result)
+    assert.same(AST.UnaryOpExpression.new(1, 3, operator, operand), result)
   end)
 
   it("should return an UnaryOpExpression node whose operand is NumberLiteralExpression and operator is negative_op", do
@@ -18,9 +18,9 @@ describe("UnaryOpExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local operator = AST.UnaryOpKind.negative_op
-    local operand = AST.NumberLiteralExpression.new(1)
+    local operand = AST.NumberLiteralExpression.new(2, 2, 1)
 
-    assert.same(AST.UnaryOpExpression.new(operator, operand), result)
+    assert.same(AST.UnaryOpExpression.new(1, 2, operator, operand), result)
   end)
 
   it("should return an UnaryOpExpression node whose operand is TableLiteralExpression and operator is length_op", do
@@ -28,9 +28,9 @@ describe("UnaryOpExpression syntax", do
     local result = Parser.new(tokens):expression()
 
     local operator = AST.UnaryOpKind.length_op
-    local operand = AST.TableLiteralExpression.new({})
+    local operand = AST.TableLiteralExpression.new(2, 3, {})
 
-    assert.same(AST.UnaryOpExpression.new(operator, operand), result)
+    assert.same(AST.UnaryOpExpression.new(1, 3, operator, operand), result)
   end)
 
   it("should guard against unfinished unary expressions", do

--- a/spec/compiler/syntax/stats/parser_assignment_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_assignment_stat_spec.lunar
@@ -7,10 +7,10 @@ describe("AssignmentStatement syntax", do
     local tokens = Lexer.new("hello = 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.NumberLiteralExpression.new(5, 5, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
   end)
 
 
@@ -18,113 +18,113 @@ describe("AssignmentStatement syntax", do
     local tokens = Lexer.new("hello['world'] = 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.IndexExpression.new(AST.Identifier.new("hello"), AST.StringLiteralExpression.new("'world'")) }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.IndexExpression.new(1, 4, AST.Identifier.new(1, 1, "hello"), AST.StringLiteralExpression.new(3, 3, "'world'")) }
+    local exprs = { AST.NumberLiteralExpression.new(8, 8, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 8, variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement with one MemberExpression using dot notation and one expression", do
     local tokens = Lexer.new("hello.world = 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.MemberExpression.new(AST.Identifier.new("hello"), AST.Identifier.new("world")) }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.MemberExpression.new(1, 3, AST.Identifier.new(1, 1, "hello"), AST.Identifier.new(3, 3, "world")) }
+    local exprs = { AST.NumberLiteralExpression.new(7, 7, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 7, variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement with two Identifiers and one expression", do
     local tokens = Lexer.new("hello, world = ..."):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello"), AST.Identifier.new("world") }
-    local exprs = { AST.VariableArgumentExpression.new() }
+    local variables = { AST.Identifier.new(1, 1, "hello"), AST.Identifier.new(4, 4, "world") }
+    local exprs = { AST.VariableArgumentExpression.new(8, 8) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 8, variables, AST.SelfAssignmentOpKind.equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement whose operator is concatenation_equal_op", do
     local tokens = Lexer.new("hello ..= 'world'"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.StringLiteralExpression.new("'world'") }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.StringLiteralExpression.new(5, 5, "'world'") }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.concatenation_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.concatenation_equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement whose operator is addition_equal_op", do
     local tokens = Lexer.new("hello += 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.NumberLiteralExpression.new(5, 5, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.addition_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.addition_equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement whose operator is subtraction_equal_op", do
     local tokens = Lexer.new("hello -= 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.NumberLiteralExpression.new(5, 5, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.subtraction_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.subtraction_equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement whose operator is multiplication_equal_op", do
     local tokens = Lexer.new("hello *= 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.NumberLiteralExpression.new(5, 5, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.multiplication_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.multiplication_equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement whose operator is division_equal_op", do
     local tokens = Lexer.new("hello /= 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.NumberLiteralExpression.new(5, 5, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.division_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.division_equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement whose operator is power_equal_op", do
     local tokens = Lexer.new("hello ^= 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.NumberLiteralExpression.new(5, 5, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.power_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.power_equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement whose operator is remainder_equal_op", do
     local tokens = Lexer.new("hello %= 1"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
-    local exprs = { AST.NumberLiteralExpression.new(1) }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
+    local exprs = { AST.NumberLiteralExpression.new(5, 5, 1) }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.remainder_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 5, variables, AST.SelfAssignmentOpKind.remainder_equal_op, exprs) }, result)
   end)
 
   it("should return one AssignmentStatement with one identifier and two expressions with concatenation_equal_op", do
     local tokens = Lexer.new("hello ..= 'world', a()"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local variables = { AST.Identifier.new("hello") }
+    local variables = { AST.Identifier.new(1, 1, "hello") }
     local exprs = {
-      AST.StringLiteralExpression.new("'world'"),
-      AST.FunctionCallExpression.new(AST.Identifier.new("a"), {})
+      AST.StringLiteralExpression.new(5, 5, "'world'"),
+      AST.FunctionCallExpression.new(8, 10, AST.Identifier.new(8, 8, "a"), {})
     }
 
-    assert.same({ AST.AssignmentStatement.new(variables, AST.SelfAssignmentOpKind.concatenation_equal_op, exprs) }, result)
+    assert.same({ AST.AssignmentStatement.new(1, 10, variables, AST.SelfAssignmentOpKind.concatenation_equal_op, exprs) }, result)
   end)
 
   it("should throw an error given an invalid left-hand side identifier", do

--- a/spec/compiler/syntax/stats/parser_break_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_break_stat_spec.lunar
@@ -7,6 +7,6 @@ describe("BreakStatement syntax", do
     local tokens = Lexer.new("break"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    assert.same({ AST.BreakStatement.new() }, result)
+    assert.same({ AST.BreakStatement.new(1, 1) }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_class_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_class_stat_spec.lunar
@@ -7,14 +7,14 @@ describe("ClassStatement syntax", do
     local tokens = Lexer.new("class C end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    assert.same({ AST.ClassStatement.new(AST.Identifier.new("C"), nil, {}) }, result)
+    assert.same({ AST.ClassStatement.new(1, 5, AST.Identifier.new(3, 3, "C"), nil, {}) }, result)
   end)
 
   it("should return one ClassStatement node whose name is 'C' and inherits from 'BaseC'", do
     local tokens = Lexer.new("class C << BaseC end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    assert.same({ AST.ClassStatement.new(AST.Identifier.new("C"), AST.Identifier.new("BaseC"), {}) }, result)
+    assert.same({ AST.ClassStatement.new(1, 9, AST.Identifier.new(3, 3, "C"), AST.Identifier.new(7, 7, "BaseC"), {}) }, result)
   end)
 
   it("should return one ClassStatement node with one instance function", do
@@ -22,8 +22,8 @@ describe("ClassStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.ClassStatement.new(AST.Identifier.new("C"), nil, {
-        AST.ClassFunctionDeclaration.new(false, AST.Identifier.new("m"), {}, {})
+      AST.ClassStatement.new(1, 13, AST.Identifier.new(3, 3, "C"), nil, {
+        AST.ClassFunctionDeclaration.new(5, 11, false, AST.Identifier.new(7, 7, "m"), {}, {})
       })
     }, result)
   end)
@@ -33,8 +33,8 @@ describe("ClassStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.ClassStatement.new(AST.Identifier.new("C"), nil, {
-        AST.ClassFunctionDeclaration.new(false, AST.Identifier.new("m"), {}, {}, AST.Identifier.new("nil"))
+      AST.ClassStatement.new(1, 16, AST.Identifier.new(3, 3, "C"), nil, {
+        AST.ClassFunctionDeclaration.new(5, 14, false, AST.Identifier.new(7, 7, "m"), {}, {}, AST.Identifier.new(12, 12, "nil"))
       })
     }, result)
   end)
@@ -44,8 +44,8 @@ describe("ClassStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.ClassStatement.new(AST.Identifier.new("C"), nil, {
-        AST.ClassFunctionDeclaration.new(true, AST.Identifier.new("m"), {}, {})
+      AST.ClassStatement.new(1, 15, AST.Identifier.new(3, 3, "C"), nil, {
+        AST.ClassFunctionDeclaration.new(5, 13, true, AST.Identifier.new(9, 9, "m"), {}, {})
       })
     }, result)
   end)
@@ -55,8 +55,8 @@ describe("ClassStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.ClassStatement.new(AST.Identifier.new("C"), nil, {
-        AST.ConstructorDeclaration.new({}, {})
+      AST.ClassStatement.new(1, 11, AST.Identifier.new(3, 3, "C"), nil, {
+        AST.ConstructorDeclaration.new(5, 9, {}, {})
       })
     }, result)
   end)
@@ -66,7 +66,7 @@ describe("ClassStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.ExpressionStatement.new(AST.FunctionCallExpression.new(AST.Identifier.new("class"), {}))
+      AST.ExpressionStatement.new(1, 3, AST.FunctionCallExpression.new(1, 3, AST.Identifier.new(1, 1, "class"), {}))
     }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_do_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_do_stat_spec.lunar
@@ -7,20 +7,20 @@ describe("DoStatement syntax", do
     local tokens = Lexer.new("do end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    assert.same({ AST.DoStatement.new({}) }, result)
+    assert.same({ AST.DoStatement.new(1, 3, {}) }, result)
   end)
 
   it("should parse two DoStatement nodes", do
     local tokens = Lexer.new("do end do end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    assert.same({ AST.DoStatement.new({}), AST.DoStatement.new({}) }, result)
+    assert.same({ AST.DoStatement.new(1, 3, {}), AST.DoStatement.new(5, 7, {}) }, result)
   end)
 
   it("should parse nested DoStatement nodes", do
     local tokens = Lexer.new("do do do end end end"):tokenize() -- de do do do de da da da
     local result = Parser.new(tokens):parse()
 
-    assert.same({ AST.DoStatement.new({ AST.DoStatement.new({ AST.DoStatement.new({}) }) }) }, result)
+    assert.same({ AST.DoStatement.new(1, 11, { AST.DoStatement.new(3, 9, {AST.DoStatement.new(5, 7, {}) }) }) }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_expression_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_expression_stat_spec.lunar
@@ -8,7 +8,7 @@ describe("ExpressionStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.ExpressionStatement.new(AST.FunctionCallExpression.new(AST.Identifier.new("hello"), {}))
+      AST.ExpressionStatement.new(1, 3, AST.FunctionCallExpression.new(1, 3, AST.Identifier.new(1, 1, "hello"), {}))
     }, result)
   end)
 

--- a/spec/compiler/syntax/stats/parser_function_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_function_stat_spec.lunar
@@ -7,14 +7,14 @@ describe("FunctionStatement syntax", do
     local tokens = Lexer.new("function test(a, b) end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_name = AST.Identifier.new("test")
+    local expected_name = AST.Identifier.new(3, 3, "test")
     local expected_params = {
-      AST.ParameterDeclaration.new(AST.Identifier.new("a")),
-      AST.ParameterDeclaration.new(AST.Identifier.new("b"))
+      AST.ParameterDeclaration.new(5, 5, AST.Identifier.new(5, 5, "a")),
+      AST.ParameterDeclaration.new(8, 8, AST.Identifier.new(8, 8, "b"))
     }
 
     assert.same({
-      AST.FunctionStatement.new(expected_name, expected_params, {}, nil)
+      AST.FunctionStatement.new(1, 11, expected_name, expected_params, {}, nil)
     }, result)
   end)
 
@@ -22,12 +22,12 @@ describe("FunctionStatement syntax", do
     local tokens = Lexer.new("function a.b:c() end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local root_ident = AST.Identifier.new("a")
-    local middle_member_expr = AST.MemberExpression.new(root_ident, AST.Identifier.new("b"))
-    local top_member_expr = AST.MemberExpression.new(middle_member_expr, AST.Identifier.new("c"), true)
+    local root_ident = AST.Identifier.new(3, 3, "a")
+    local middle_member_expr = AST.MemberExpression.new(3, 5, root_ident, AST.Identifier.new(5, 5, "b"))
+    local top_member_expr = AST.MemberExpression.new(3, 7, middle_member_expr, AST.Identifier.new(7, 7, "c"), true)
 
     assert.same({
-      AST.FunctionStatement.new(top_member_expr, {}, {}, nil)
+      AST.FunctionStatement.new(1, 11, top_member_expr, {}, {}, nil)
     }, result)
   end)
 
@@ -36,7 +36,7 @@ describe("FunctionStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.FunctionStatement.new(AST.Identifier.new("test"), {}, {}, nil, true)
+      AST.FunctionStatement.new(1, 9, AST.Identifier.new(5, 5, "test"), {}, {}, nil, true)
     }, result)
   end)
 
@@ -45,7 +45,7 @@ describe("FunctionStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.FunctionStatement.new(AST.Identifier.new("test"), {}, {}, AST.Identifier.new("string"), true)
+      AST.FunctionStatement.new(1, 12, AST.Identifier.new(5, 5, "test"), {}, {}, AST.Identifier.new(10, 10, "string"), true)
     }, result)
   end)
 
@@ -53,15 +53,15 @@ describe("FunctionStatement syntax", do
     local tokens = Lexer.new("function test(a: string, b, c: any) end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_name = AST.Identifier.new("test")
+    local expected_name = AST.Identifier.new(3, 3, "test")
     local expected_params = {
-      AST.ParameterDeclaration.new(AST.Identifier.new("a", AST.Identifier.new("string"))),
-      AST.ParameterDeclaration.new(AST.Identifier.new("b", nil)),
-      AST.ParameterDeclaration.new(AST.Identifier.new("c", AST.Identifier.new("any"))),
+      AST.ParameterDeclaration.new(5, 8, AST.Identifier.new(5, 5, "a", AST.Identifier.new(8, 8, "string"))),
+      AST.ParameterDeclaration.new(11, 11, AST.Identifier.new(11, 11, "b", nil)),
+      AST.ParameterDeclaration.new(14, 17, AST.Identifier.new(14, 14, "c", AST.Identifier.new(17, 17, "any"))),
     }
 
     assert.same({
-      AST.FunctionStatement.new(expected_name, expected_params, {}, nil)
+      AST.FunctionStatement.new(1, 20, expected_name, expected_params, {}, nil)
     }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_generic_for_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_generic_for_stat_spec.lunar
@@ -7,13 +7,13 @@ describe("GenericForStatement syntax", do
     local tokens = Lexer.new("for i in pairs() do end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_identifiers = { AST.Identifier.new("i") }
+    local expected_identifiers = { AST.Identifier.new(3, 3, "i") }
     local expected_exprlist = {
-      AST.FunctionCallExpression.new(AST.Identifier.new("pairs"), {})
+      AST.FunctionCallExpression.new(7, 9, AST.Identifier.new(7, 7, "pairs"), {})
     }
 
     assert.same({
-      AST.GenericForStatement.new(expected_identifiers, expected_exprlist, {})
+      AST.GenericForStatement.new(1, 13, expected_identifiers, expected_exprlist, {})
     }, result)
   end)
 
@@ -21,13 +21,13 @@ describe("GenericForStatement syntax", do
     local tokens = Lexer.new("for i, v in pairs() do end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_identifiers = { AST.Identifier.new("i"), AST.Identifier.new("v") }
+    local expected_identifiers = { AST.Identifier.new(3, 3, "i"), AST.Identifier.new(6, 6, "v") }
     local expected_exprlist = {
-      AST.FunctionCallExpression.new(AST.Identifier.new("pairs"), {})
+      AST.FunctionCallExpression.new(10, 12, AST.Identifier.new(10, 10, "pairs"), {})
     }
 
     assert.same({
-      AST.GenericForStatement.new(expected_identifiers, expected_exprlist, {})
+      AST.GenericForStatement.new(1, 16, expected_identifiers, expected_exprlist, {})
     }, result)
   end)
 
@@ -35,14 +35,14 @@ describe("GenericForStatement syntax", do
     local tokens = Lexer.new("for i, v in next, t do end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_identifiers = { AST.Identifier.new("i"), AST.Identifier.new("v") }
+    local expected_identifiers = { AST.Identifier.new(3, 3, "i"), AST.Identifier.new(6, 6, "v") }
     local expected_exprlist = {
-      AST.Identifier.new("next"),
-      AST.Identifier.new("t")
+      AST.Identifier.new(10, 10, "next"),
+      AST.Identifier.new(13, 13, "t")
     }
 
     assert.same({
-      AST.GenericForStatement.new(expected_identifiers, expected_exprlist, {})
+      AST.GenericForStatement.new(1, 17, expected_identifiers, expected_exprlist, {})
     }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_if_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_if_stat_spec.lunar
@@ -7,9 +7,9 @@ describe("IfStatement syntax", do
     local tokens = Lexer.new("if true then end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_expr = AST.BooleanLiteralExpression.new(true)
+    local expected_expr = AST.BooleanLiteralExpression.new(3, 3, true)
 
-    assert.same({ AST.IfStatement.new(expected_expr, {}) }, result)
+    assert.same({ AST.IfStatement.new(1, 7, expected_expr, {}) }, result)
   end)
 
   it("should return one IfStatement node with one elseif branch", do
@@ -17,11 +17,12 @@ describe("IfStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     -- since all branches here has the same
-    local expected_expr = AST.BooleanLiteralExpression.new(false)
+    local expected_expr_1 = AST.BooleanLiteralExpression.new(3, 3, false)
+    local expected_expr_2 = AST.BooleanLiteralExpression.new(9, 9, false)
 
     assert.same({
-      AST.IfStatement.new(expected_expr, {})
-        :push_elseif(AST.IfStatement.new(expected_expr, {}))
+      AST.IfStatement.new(1, 13, expected_expr_1, {})
+        :push_elseif(AST.IfStatement.new(7, 11, expected_expr_2, {}))
     }, result)
   end)
 
@@ -29,12 +30,13 @@ describe("IfStatement syntax", do
     local tokens = Lexer.new("if false then elseif false then else end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_expr = AST.BooleanLiteralExpression.new(false)
+    local expected_expr_1 = AST.BooleanLiteralExpression.new(3, 3, false)
+    local expected_expr_2 = AST.BooleanLiteralExpression.new(9, 9, false)
 
     assert.same({
-      AST.IfStatement.new(expected_expr, {})
-        :push_elseif(AST.IfStatement.new(expected_expr, {}, {}))
-        :set_else(AST.IfStatement.new(nil, {}))
+      AST.IfStatement.new(1, 15, expected_expr_1, {})
+        :push_elseif(AST.IfStatement.new(7, 11, expected_expr_2, {}, {}))
+        :set_else(AST.IfStatement.new(13, 13, nil, {}))
     }, result)
   end)
 
@@ -42,10 +44,11 @@ describe("IfStatement syntax", do
     local tokens = Lexer.new("if false then if false then end end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_expr = AST.BooleanLiteralExpression.new(false)
+    local expected_expr_1 = AST.BooleanLiteralExpression.new(3, 3, false)
+    local expected_expr_2 = AST.BooleanLiteralExpression.new(9, 9, false)
 
     assert.same({
-      AST.IfStatement.new(expected_expr, { AST.IfStatement.new(expected_expr, {}) })
+      AST.IfStatement.new(1, 15, expected_expr_1, { AST.IfStatement.new(7, 13, expected_expr_2, {}) })
     }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_range_for_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_range_for_stat_spec.lunar
@@ -8,10 +8,10 @@ describe("RangeForStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.RangeForStatement.new(
-        AST.Identifier.new("i"),
-        AST.NumberLiteralExpression.new(1),
-        AST.NumberLiteralExpression.new(2),
+      AST.RangeForStatement.new(1, 14,
+        AST.Identifier.new(3, 3, "i"),
+        AST.NumberLiteralExpression.new(7, 7, 1),
+        AST.NumberLiteralExpression.new(10, 10, 2),
         nil,
         {}
       )
@@ -23,11 +23,11 @@ describe("RangeForStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.RangeForStatement.new(
-        AST.Identifier.new("i"),
-        AST.NumberLiteralExpression.new(1),
-        AST.NumberLiteralExpression.new(2),
-        AST.NumberLiteralExpression.new(3),
+      AST.RangeForStatement.new(1, 17,
+        AST.Identifier.new(3, 3, "i"),
+        AST.NumberLiteralExpression.new(7, 7, 1),
+        AST.NumberLiteralExpression.new(10, 10, 2),
+        AST.NumberLiteralExpression.new(13, 13, 3),
         {}
       )
     }, result)

--- a/spec/compiler/syntax/stats/parser_repeat_until_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_repeat_until_stat_spec.lunar
@@ -7,8 +7,8 @@ describe("RepeatUntilStatement syntax", do
     local tokens = Lexer.new("repeat until true"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expr = AST.BooleanLiteralExpression.new(true)
+    local expr = AST.BooleanLiteralExpression.new(5, 5, true)
 
-    assert.same({ AST.RepeatUntilStatement.new({}, expr) }, result)
+    assert.same({ AST.RepeatUntilStatement.new(1, 5, {}, expr) }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_return_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_return_stat_spec.lunar
@@ -7,24 +7,24 @@ describe("ReturnStatement syntax", do
     local tokens = Lexer.new("return"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    assert.same({ AST.ReturnStatement.new() }, result)
+    assert.same({ AST.ReturnStatement.new(1, 1) }, result)
   end)
 
   it("should return one ReturnStatement node with one expression", do
     local tokens = Lexer.new("return nil"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_expr_list = { AST.NilLiteralExpression.new() }
+    local expected_expr_list = { AST.NilLiteralExpression.new(3, 3) }
 
-    assert.same({ AST.ReturnStatement.new(expected_expr_list) }, result)
+    assert.same({ AST.ReturnStatement.new(1, 3, expected_expr_list) }, result)
   end)
 
   it("should return one ReturnStatement node with two expressions", do
     local tokens = Lexer.new("return nil, nil"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expected_expr_list = { AST.NilLiteralExpression.new(), AST.NilLiteralExpression.new() }
+    local expected_expr_list = { AST.NilLiteralExpression.new(3, 3), AST.NilLiteralExpression.new(6, 6) }
 
-    assert.same({ AST.ReturnStatement.new(expected_expr_list) }, result)
+    assert.same({ AST.ReturnStatement.new(1, 6, expected_expr_list) }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_variable_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_variable_stat_spec.lunar
@@ -7,32 +7,32 @@ describe("VariableStatement syntax", do
     local tokens = Lexer.new("local a, b = 1, 2"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local names = { AST.Identifier.new("a"), AST.Identifier.new("b") }
+    local names = { AST.Identifier.new(3, 3, "a"), AST.Identifier.new(6, 6, "b") }
     local exprs = {
-      AST.NumberLiteralExpression.new(1),
-      AST.NumberLiteralExpression.new(2)
+      AST.NumberLiteralExpression.new(10, 10, 1),
+      AST.NumberLiteralExpression.new(13, 13, 2)
     }
 
-    assert.same({ AST.VariableStatement.new(names, exprs) }, result)
+    assert.same({ AST.VariableStatement.new(1, 13, names, exprs) }, result)
   end)
 
   it("should return one VariableSyntax node with two names and one expression", do
     local tokens = Lexer.new("local a, b = ..."):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local names = { AST.Identifier.new("a"), AST.Identifier.new("b") }
-    local exprs = { AST.VariableArgumentExpression.new() }
+    local names = { AST.Identifier.new(3, 3, "a"), AST.Identifier.new(6, 6, "b") }
+    local exprs = { AST.VariableArgumentExpression.new(10, 10) }
 
-    assert.same({ AST.VariableStatement.new(names, exprs) }, result)
+    assert.same({ AST.VariableStatement.new(1, 10, names, exprs) }, result)
   end)
 
   it("should return one VariableSyntax node with one name and no expression", do
     local tokens = Lexer.new("local a"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local names = { AST.Identifier.new("a") }
+    local names = { AST.Identifier.new(3, 3, "a") }
 
-    assert.same({ AST.VariableStatement.new(names, nil) }, result)
+    assert.same({ AST.VariableStatement.new(1, 3, names, nil) }, result)
   end)
 
   it("should return two VariableSyntax node with one name and one expression, each", do
@@ -40,8 +40,8 @@ describe("VariableStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.VariableStatement.new({ AST.Identifier.new("a") }, { AST.NumberLiteralExpression.new(1) }),
-      AST.VariableStatement.new({ AST.Identifier.new("b") }, { AST.NumberLiteralExpression.new(2) })
+      AST.VariableStatement.new(1, 7, { AST.Identifier.new(3, 3, "a") }, { AST.NumberLiteralExpression.new(7, 7, 1) }),
+      AST.VariableStatement.new(9, 15, { AST.Identifier.new(11, 11, "b") }, { AST.NumberLiteralExpression.new(15, 15, 2) })
     }, result)
   end)
 
@@ -50,9 +50,9 @@ describe("VariableStatement syntax", do
     local result = Parser.new(tokens):parse()
 
     assert.same({
-      AST.VariableStatement.new(
-        { AST.Identifier.new("a", AST.Identifier.new("string")), AST.Identifier.new("b"), AST.Identifier.new("c", AST.Identifier.new("any")) },
-        { AST.NumberLiteralExpression.new(1), AST.NumberLiteralExpression.new(2), AST.NumberLiteralExpression.new(3) }),
+      AST.VariableStatement.new(1, 25,
+        { AST.Identifier.new(3, 3, "a", AST.Identifier.new(6, 6, "string")), AST.Identifier.new(9, 9, "b"), AST.Identifier.new(12, 12, "c", AST.Identifier.new(15, 15, "any")) },
+        { AST.NumberLiteralExpression.new(19, 19, 1), AST.NumberLiteralExpression.new(22, 22, 2), AST.NumberLiteralExpression.new(25, 25, 3) }),
     }, result)
   end)
 
@@ -60,8 +60,9 @@ describe("VariableStatement syntax", do
     local tokens = Lexer.new("local a: string"):tokenize()
     local result = Parser.new(tokens):parse()
 
+    assert.same(AST.Identifier.new(3, 3, "a", AST.Identifier.new(6, 6, "string")), result[1].identlist[1])
     assert.same({
-      AST.VariableStatement.new({ AST.Identifier.new("a", AST.Identifier.new("string")) }),
+      AST.VariableStatement.new(1, 6, { AST.Identifier.new(3, 3, "a", AST.Identifier.new(6, 6, "string")) }),
     }, result)
   end)
 end)

--- a/spec/compiler/syntax/stats/parser_while_stat_spec.lunar
+++ b/spec/compiler/syntax/stats/parser_while_stat_spec.lunar
@@ -7,8 +7,8 @@ describe("WhileStatement syntax", do
     local tokens = Lexer.new("while true do end"):tokenize()
     local result = Parser.new(tokens):parse()
 
-    local expr = AST.BooleanLiteralExpression.new(true)
+    local expr = AST.BooleanLiteralExpression.new(3, 3, true)
 
-    assert.same({ AST.WhileStatement.new(expr, {}) }, result)
+    assert.same({ AST.WhileStatement.new(1, 7, expr, {}) }, result)
   end)
 end)


### PR DESCRIPTION
This addition assigns "start_pos" and "end_pos" indexes of the lexed tokens.

Storing token indices rather than the token objects themselves means that the tokens _along with_ the AST must be known in order to provide proper diagnostic information.

There are a few advantages, however, to storing positions. For one, it means that things like trivia (if we decide to keep style through transpilation) will *not* have to be stored on nodes, as it will be much easier to walk through through each token looking for trivia, and placing them in the exact intented location using start_pos and end_pos as references.

All of the AST node constructors have been updated to take in the start_pos and end_pos as the first two parameters.