### PR TITLE
Hide GCC warnings when compiling Lua 5.1

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -74,7 +74,7 @@ compile_lib() {
   NAME=$1;DIR=$2;O_FILES="";
   shift;shift;
   for f in $DIR/*.c; do
-    $CUR_CC -O2 -Wall -Wextra $@ -c -o ${f%.c}.o $f
+    $CUR_CC -O2 $@ -c -o ${f%.c}.o $f
     O_FILES="$O_FILES ${f%.c}.o"
   done
   $CUR_AR $NAME $O_FILES

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,5 +1,4 @@
 echo "! Starting to compile Lunar..."
-echo "# You will see a lot of messages, this is normal."
 
 # Versions
 LUA_VER=5.1.5
@@ -98,7 +97,6 @@ $CUR_CC -Os bin/lunarc.lua.c liblua.a lfs.a -I$LUA_DIR/src -lm -o bin/lunarc.exe
 $CUR_STRIP bin/lunarc.exe
 
 # Finished
-echo
-echo "+ Successfully compiled Lunar"
+echo "! Successfully compiled Lunar"
 echo "# Linux x64: build/bin/lunarc"
 echo "# Windows x86: build/bin/lunarc.exe"


### PR DESCRIPTION
This removes the additional arguments to the GCC compiler that shows all warning messages.